### PR TITLE
Add HTTP client

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,6 @@
 Style/Documentation:
   Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*.rb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     metabase (0.1.0)
+      faraday
 
 GEM
   remote: https://rubygems.org/
@@ -10,7 +11,10 @@ GEM
     awesome_print (1.8.0)
     coderay (1.1.2)
     diff-lcs (1.3)
+    faraday (0.15.1)
+      multipart-post (>= 1.2, < 3)
     method_source (0.9.0)
+    multipart-post (2.0.0)
     parallel (1.12.1)
     parser (2.5.1.0)
       ast (~> 2.4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,8 @@ PATH
   remote: .
   specs:
     metabase (0.1.0)
-      faraday
+      faraday (~> 0.8)
+      faraday_middleware
 
 GEM
   remote: https://rubygems.org/
@@ -13,6 +14,8 @@ GEM
     diff-lcs (1.3)
     faraday (0.15.1)
       multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.12.2)
+      faraday (>= 0.7.4, < 1.0)
     method_source (0.9.0)
     multipart-post (2.0.0)
     parallel (1.12.1)

--- a/lib/metabase.rb
+++ b/lib/metabase.rb
@@ -1,4 +1,5 @@
 require 'metabase/version'
+require 'metabase/client'
 
 module Metabase
   # Your code goes here...

--- a/lib/metabase/client.rb
+++ b/lib/metabase/client.rb
@@ -1,5 +1,6 @@
 require 'faraday'
 require 'faraday_middleware'
+require 'metabase/error'
 
 module Metabase
   class Client
@@ -16,6 +17,8 @@ module Metabase
     def login
       params = { username: @username, password: @password }
       response = @connection.post '/api/session', params
+      error = Error.from_response(response)
+      raise error if error
       @session_token = response.body['id']
     end
   end

--- a/lib/metabase/client.rb
+++ b/lib/metabase/client.rb
@@ -9,5 +9,10 @@ module Metabase
         c.adapter Faraday.default_adapter
       end
     end
+
+    def login
+      params = {username: @username, password: @password}
+      @connection.post '/api/session', params
+    end
   end
 end

--- a/lib/metabase/client.rb
+++ b/lib/metabase/client.rb
@@ -1,4 +1,5 @@
 require 'faraday'
+require 'faraday_middleware'
 
 module Metabase
   class Client
@@ -6,6 +7,7 @@ module Metabase
       @username = username
       @password = password
       @connection = Faraday.new(url: url) do |c|
+        c.request :json
         c.adapter Faraday.default_adapter
       end
     end

--- a/lib/metabase/client.rb
+++ b/lib/metabase/client.rb
@@ -8,13 +8,15 @@ module Metabase
       @password = password
       @connection = Faraday.new(url: url) do |c|
         c.request :json
+        c.response :json, content_type: /\bjson$/
         c.adapter Faraday.default_adapter
       end
     end
 
     def login
-      params = {username: @username, password: @password}
-      @connection.post '/api/session', params
+      params = { username: @username, password: @password }
+      response = @connection.post '/api/session', params
+      @session_token = response.body['id']
     end
   end
 end

--- a/lib/metabase/client.rb
+++ b/lib/metabase/client.rb
@@ -1,8 +1,13 @@
+require 'faraday'
+
 module Metabase
   class Client
-    def initialize(username:, password:)
+    def initialize(url:, username:, password:)
       @username = username
       @password = password
+      @connection = Faraday.new(url: url) do |c|
+        c.adapter Faraday.default_adapter
+      end
     end
   end
 end

--- a/lib/metabase/client.rb
+++ b/lib/metabase/client.rb
@@ -1,0 +1,8 @@
+module Metabase
+  class Client
+    def initialize(username:, password:)
+      @username = username
+      @password = password
+    end
+  end
+end

--- a/lib/metabase/error.rb
+++ b/lib/metabase/error.rb
@@ -1,0 +1,23 @@
+module Metabase
+  class Error < StandardError
+    def self.from_response(response)
+      klass =
+        case response.status
+        when 400 then BadRequest
+        end
+      klass.new(response) if klass
+    end
+
+    def initialize(response = nil)
+      @response = response
+      super(build_error_message)
+    end
+
+    def build_error_message
+      return nil if @response.nil?
+      @response.body
+    end
+  end
+
+  class BadRequest < Error; end
+end

--- a/metabase.gemspec
+++ b/metabase.gemspec
@@ -21,7 +21,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'faraday'
+  spec.add_runtime_dependency 'faraday', '~> 0.8'
+  spec.add_runtime_dependency 'faraday_middleware'
 
   spec.add_development_dependency 'awesome_print'
   spec.add_development_dependency 'bundler', '~> 1.16'

--- a/metabase.gemspec
+++ b/metabase.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_runtime_dependency 'faraday'
+
   spec.add_development_dependency 'awesome_print'
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'pry'

--- a/spec/metabase/client_spec.rb
+++ b/spec/metabase/client_spec.rb
@@ -1,13 +1,21 @@
 RSpec.describe Metabase::Client do
   let(:client) do
     Metabase::Client.new(
-      url: 'https://example.com',
+      url: 'http://localhost:3030',
       username: 'mb@example.com',
       password: 'p@ssw0rd'
     )
   end
 
-  it 'has a client' do
-    expect(client).not_to be nil
+  describe 'login' do
+    context 'success' do
+      it 'returns a session token' do
+        expect(client.login).to eq '12345678'
+      end
+    end
+
+    context 'incorrect username or password' do
+      pending
+    end
   end
 end

--- a/spec/metabase/client_spec.rb
+++ b/spec/metabase/client_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe Metabase::Client do
+  let(:client) do
+    Metabase::Client.new(username: 'mb@example.com', password: 'p@ssw0rd')
+  end
+
+  it 'has a client' do
+    expect(client).not_to be nil
+  end
+end

--- a/spec/metabase/client_spec.rb
+++ b/spec/metabase/client_spec.rb
@@ -7,6 +7,14 @@ RSpec.describe Metabase::Client do
     )
   end
 
+  let(:incorrect_password) do
+    Metabase::Client.new(
+      url: 'http://localhost:3030',
+      username: 'mb@example.com',
+      password: 'incorrect'
+    )
+  end
+
   describe 'login' do
     context 'success' do
       it 'returns a session token' do
@@ -15,7 +23,9 @@ RSpec.describe Metabase::Client do
     end
 
     context 'incorrect username or password' do
-      pending
+      it 'raises error' do
+        expect { incorrect_password.login }.to raise_error(Metabase::BadRequest)
+      end
     end
   end
 end

--- a/spec/metabase/client_spec.rb
+++ b/spec/metabase/client_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Metabase::Client do
   describe 'login' do
     context 'success' do
       it 'returns a session token' do
-        expect(client.login).to eq '12345678'
+        expect(client.login).to match(/[a-z0-9-]{36}/)
       end
     end
 

--- a/spec/metabase/client_spec.rb
+++ b/spec/metabase/client_spec.rb
@@ -1,6 +1,10 @@
 RSpec.describe Metabase::Client do
   let(:client) do
-    Metabase::Client.new(username: 'mb@example.com', password: 'p@ssw0rd')
+    Metabase::Client.new(
+      url: 'https://example.com',
+      username: 'mb@example.com',
+      password: 'p@ssw0rd'
+    )
   end
 
   it 'has a client' do


### PR DESCRIPTION
MetabaseとHTTP通信してログインできるようにします。

- HTTPクライアントライブラリはfaradayを採用
  - https://www.ruby-toolbox.com/categories/http_clients で1位で定番
  - 使ったことがあるので楽
- faraday_middlewareでJSONのエンコード・デコードを透過的にやるようにした
  - [faraday 0.8以降の書き方](https://github.com/lostisland/faraday_middleware#examples)をしているのでgemspecの依存は0.8以降にした
- Metrics/BlockLengthで怒られたのでspec以下を除外
- エラー処理は[octokit](https://github.com/octokit/octokit.rb/blob/master/lib/octokit/error.rb)を参考にした
  - エラーを細かくしたりメッセージを親切にするのはあとで