### PR TITLE
Add User endpoint

### DIFF
--- a/lib/metabase.rb
+++ b/lib/metabase.rb
@@ -2,5 +2,4 @@ require 'metabase/version'
 require 'metabase/client'
 
 module Metabase
-  # Your code goes here...
 end

--- a/lib/metabase/client.rb
+++ b/lib/metabase/client.rb
@@ -19,13 +19,5 @@ module Metabase
         c.adapter Faraday.default_adapter
       end
     end
-
-    def login
-      params = { username: @username, password: @password }
-      response = @connection.post '/api/session', params
-      error = Error.from_response(response)
-      raise error if error
-      @token = response.body['id']
-    end
   end
 end

--- a/lib/metabase/client.rb
+++ b/lib/metabase/client.rb
@@ -1,9 +1,12 @@
 require 'faraday'
 require 'faraday_middleware'
+require 'metabase/endpoint'
 require 'metabase/error'
 
 module Metabase
   class Client
+    include Endpoint
+
     def initialize(url:, username:, password:)
       @username = username
       @password = password

--- a/lib/metabase/client.rb
+++ b/lib/metabase/client.rb
@@ -7,16 +7,9 @@ module Metabase
     include Endpoint
 
     def initialize(url:, username:, password:)
+      @url = url
       @username = username
       @password = password
-      headers = {
-        user_agent: "MetabaseRuby/#{VERSION} (#{RUBY_ENGINE}#{RUBY_VERSION})"
-      }
-      @connection = Faraday.new(url: url, headers: headers) do |c|
-        c.request :json
-        c.response :json, content_type: /\bjson$/
-        c.adapter Faraday.default_adapter
-      end
     end
   end
 end

--- a/lib/metabase/client.rb
+++ b/lib/metabase/client.rb
@@ -25,7 +25,7 @@ module Metabase
       response = @connection.post '/api/session', params
       error = Error.from_response(response)
       raise error if error
-      @session_token = response.body['id']
+      @token = response.body['id']
     end
   end
 end

--- a/lib/metabase/client.rb
+++ b/lib/metabase/client.rb
@@ -1,10 +1,9 @@
-require 'faraday'
-require 'faraday_middleware'
+require 'metabase/connection'
 require 'metabase/endpoint'
-require 'metabase/error'
 
 module Metabase
   class Client
+    include Connection
     include Endpoint
 
     def initialize(url:, username:, password:)

--- a/lib/metabase/client.rb
+++ b/lib/metabase/client.rb
@@ -10,7 +10,10 @@ module Metabase
     def initialize(url:, username:, password:)
       @username = username
       @password = password
-      @connection = Faraday.new(url: url) do |c|
+      headers = {
+        user_agent: "MetabaseRuby/#{VERSION} (#{RUBY_ENGINE}#{RUBY_VERSION})"
+      }
+      @connection = Faraday.new(url: url, headers: headers) do |c|
         c.request :json
         c.response :json, content_type: /\bjson$/
         c.adapter Faraday.default_adapter

--- a/lib/metabase/connection.rb
+++ b/lib/metabase/connection.rb
@@ -9,7 +9,8 @@ module Metabase
         c.request :json
         c.response :json, content_type: /\bjson$/
         c.adapter Faraday.default_adapter
-        c.headers['User-Agent'] = "MetabaseRuby/#{VERSION} (#{RUBY_ENGINE}#{RUBY_VERSION})"
+        c.headers['User-Agent'] =
+          "MetabaseRuby/#{VERSION} (#{RUBY_ENGINE}#{RUBY_VERSION})"
       end
     end
   end

--- a/lib/metabase/connection.rb
+++ b/lib/metabase/connection.rb
@@ -1,0 +1,8 @@
+require 'faraday'
+require 'faraday_middleware'
+require 'metabase/error'
+
+module Metabase
+  module Connection
+  end
+end

--- a/lib/metabase/connection.rb
+++ b/lib/metabase/connection.rb
@@ -4,5 +4,13 @@ require 'metabase/error'
 
 module Metabase
   module Connection
+    def connection
+      @connection ||= Faraday.new(url: @url) do |c|
+        c.request :json
+        c.response :json, content_type: /\bjson$/
+        c.adapter Faraday.default_adapter
+        c.headers['User-Agent'] = "MetabaseRuby/#{VERSION} (#{RUBY_ENGINE}#{RUBY_VERSION})"
+      end
+    end
   end
 end

--- a/lib/metabase/connection.rb
+++ b/lib/metabase/connection.rb
@@ -4,6 +4,8 @@ require 'metabase/error'
 
 module Metabase
   module Connection
+    private
+
     def connection
       @connection ||= Faraday.new(url: @url) do |c|
         c.request :json

--- a/lib/metabase/endpoint.rb
+++ b/lib/metabase/endpoint.rb
@@ -1,0 +1,7 @@
+require 'metabase/endpoint/user'
+
+module Metabase
+  module Endpoint
+    include User
+  end
+end

--- a/lib/metabase/endpoint.rb
+++ b/lib/metabase/endpoint.rb
@@ -1,7 +1,9 @@
+require 'metabase/endpoint/session'
 require 'metabase/endpoint/user'
 
 module Metabase
   module Endpoint
+    include Session
     include User
   end
 end

--- a/lib/metabase/endpoint/session.rb
+++ b/lib/metabase/endpoint/session.rb
@@ -1,0 +1,13 @@
+module Metabase
+  module Endpoint
+    module Session
+      def login
+        params = { username: @username, password: @password }
+        response = @connection.post '/api/session', params
+        error = Error.from_response(response)
+        raise error if error
+        @token = response.body['id']
+      end
+    end
+  end
+end

--- a/lib/metabase/endpoint/session.rb
+++ b/lib/metabase/endpoint/session.rb
@@ -3,7 +3,7 @@ module Metabase
     module Session
       def login
         params = { username: @username, password: @password }
-        response = @connection.post '/api/session', params
+        response = connection.post '/api/session', params
         error = Error.from_response(response)
         raise error if error
         @token = response.body['id']

--- a/lib/metabase/endpoint/user.rb
+++ b/lib/metabase/endpoint/user.rb
@@ -1,0 +1,6 @@
+module Metabase
+  module Endpoint
+    module User
+    end
+  end
+end

--- a/lib/metabase/endpoint/user.rb
+++ b/lib/metabase/endpoint/user.rb
@@ -2,7 +2,7 @@ module Metabase
   module Endpoint
     module User
       def current_user
-        response = @connection.get do |req|
+        response = connection.get do |req|
           req.url '/api/user/current'
           req.headers['X-Metabase-Session'] = @token
         end

--- a/lib/metabase/endpoint/user.rb
+++ b/lib/metabase/endpoint/user.rb
@@ -1,6 +1,16 @@
 module Metabase
   module Endpoint
     module User
+      def current_user
+        response = @connection.get do |req|
+          req.url '/api/user/current'
+          req.headers['X-Metabase-Session'] = @token
+        end
+
+        error = Error.from_response(response)
+        raise error if error
+        response.body
+      end
     end
   end
 end

--- a/spec/metabase/endpoint/session_spec.rb
+++ b/spec/metabase/endpoint/session_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Metabase::Client do
+RSpec.describe Metabase::Endpoint::Session do
   let(:client) do
     Metabase::Client.new(
       url: 'http://localhost:3030',

--- a/spec/metabase/endpoint/user_spec.rb
+++ b/spec/metabase/endpoint/user_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe Metabase::Endpoint::User do
+  let(:client) do
+    Metabase::Client.new(
+      url: 'http://localhost:3030',
+      username: 'mb@example.com',
+      password: 'p@ssw0rd'
+    )
+  end
+
+  before do
+    client.login
+  end
+
+  describe 'current_user', vcr: true do
+    context 'success' do
+      it 'returns the current user' do
+        user = client.current_user
+
+        expect(user['email']).to eq('mb@example.com')
+      end
+    end
+  end
+end

--- a/spec/metabase/endpoint/user_spec.rb
+++ b/spec/metabase/endpoint/user_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Metabase::Endpoint::User do
     context 'success' do
       it 'returns the current user' do
         user = client.current_user
-
         expect(user['email']).to eq('mb@example.com')
       end
     end

--- a/spec/vcr_cassettes/Metabase_Endpoint_Session/login/incorrect_username_or_password/raises_error.yml
+++ b/spec/vcr_cassettes/Metabase_Endpoint_Session/login/incorrect_username_or_password/raises_error.yml
@@ -5,10 +5,10 @@ http_interactions:
     uri: http://localhost:3030/api/session
     body:
       encoding: UTF-8
-      string: '{"username":"mb@example.com","password":"p@ssw0rd"}'
+      string: '{"username":"mb@example.com","password":"incorrect"}'
     headers:
       User-Agent:
-      - Faraday v0.15.1
+      - MetabaseRuby/0.1.0 (ruby2.5.1)
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -17,28 +17,28 @@ http_interactions:
       - "*/*"
   response:
     status:
-      code: 200
-      message: OK
+      code: 400
+      message: Bad Request
     headers:
       Date:
-      - Sat, 12 May 2018 10:52:35 GMT
+      - Sun, 13 May 2018 00:21:28 GMT
       Cache-Control:
       - max-age=0, no-cache, must-revalidate, proxy-revalidate
       Expires:
       - Tue, 03 Jul 2001 06:00:00 GMT
       Last-Modified:
-      - Sat, 12 May 2018 10:52:35 +0000
+      - Sun, 13 May 2018 00:21:28 +0000
       Strict-Transport-Security:
       - max-age=31536000
       Content-Type:
       - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '55'
       Server:
       - Jetty(9.2.z-SNAPSHOT)
     body:
-      encoding: ASCII-8BIT
-      string: '{"id":"ac4bea80-0d25-44e4-ba60-6eaeda0abd68"}'
+      encoding: UTF-8
+      string: '{"errors":{"password":"did not match stored password"}}'
     http_version: 
-  recorded_at: Sat, 12 May 2018 10:52:30 GMT
+  recorded_at: Sun, 13 May 2018 00:21:26 GMT
 recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/Metabase_Endpoint_Session/login/success/returns_a_session_token.yml
+++ b/spec/vcr_cassettes/Metabase_Endpoint_Session/login/success/returns_a_session_token.yml
@@ -5,10 +5,10 @@ http_interactions:
     uri: http://localhost:3030/api/session
     body:
       encoding: UTF-8
-      string: '{"username":"mb@example.com","password":"incorrect"}'
+      string: '{"username":"mb@example.com","password":"p@ssw0rd"}'
     headers:
       User-Agent:
-      - Faraday v0.15.1
+      - MetabaseRuby/0.1.0 (ruby2.5.1)
       Content-Type:
       - application/json
       Accept-Encoding:
@@ -17,28 +17,28 @@ http_interactions:
       - "*/*"
   response:
     status:
-      code: 400
-      message: Bad Request
+      code: 200
+      message: OK
     headers:
       Date:
-      - Sat, 12 May 2018 10:52:35 GMT
+      - Sun, 13 May 2018 00:21:28 GMT
       Cache-Control:
       - max-age=0, no-cache, must-revalidate, proxy-revalidate
       Expires:
       - Tue, 03 Jul 2001 06:00:00 GMT
       Last-Modified:
-      - Sat, 12 May 2018 10:52:35 +0000
+      - Sun, 13 May 2018 00:21:28 +0000
       Strict-Transport-Security:
       - max-age=31536000
       Content-Type:
       - application/json; charset=utf-8
-      Content-Length:
-      - '55'
+      Transfer-Encoding:
+      - chunked
       Server:
       - Jetty(9.2.z-SNAPSHOT)
     body:
-      encoding: UTF-8
-      string: '{"errors":{"password":"did not match stored password"}}'
+      encoding: ASCII-8BIT
+      string: '{"id":"22e6399e-b63e-4178-b460-730c4238a05c"}'
     http_version: 
-  recorded_at: Sat, 12 May 2018 10:52:30 GMT
+  recorded_at: Sun, 13 May 2018 00:21:27 GMT
 recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/Metabase_Endpoint_User/current_user/success/returns_the_current_user.yml
+++ b/spec/vcr_cassettes/Metabase_Endpoint_User/current_user/success/returns_the_current_user.yml
@@ -1,0 +1,86 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:3030/api/session
+    body:
+      encoding: UTF-8
+      string: '{"username":"mb@example.com","password":"p@ssw0rd"}'
+    headers:
+      User-Agent:
+      - MetabaseRuby/0.1.0 (ruby2.5.1)
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 12 May 2018 15:11:48 GMT
+      Cache-Control:
+      - max-age=0, no-cache, must-revalidate, proxy-revalidate
+      Expires:
+      - Tue, 03 Jul 2001 06:00:00 GMT
+      Last-Modified:
+      - Sat, 12 May 2018 15:11:48 +0000
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Jetty(9.2.z-SNAPSHOT)
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"420c1892-2535-4c93-96fa-23f0a44206d6"}'
+    http_version: 
+  recorded_at: Sat, 12 May 2018 15:11:44 GMT
+- request:
+    method: get
+    uri: http://localhost:3030/api/user/current
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - MetabaseRuby/0.1.0 (ruby2.5.1)
+      X-Metabase-Session:
+      - 420c1892-2535-4c93-96fa-23f0a44206d6
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 12 May 2018 15:11:48 GMT
+      Cache-Control:
+      - max-age=0, no-cache, must-revalidate, proxy-revalidate
+      Expires:
+      - Tue, 03 Jul 2001 06:00:00 GMT
+      Last-Modified:
+      - Sat, 12 May 2018 15:11:48 +0000
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Jetty(9.2.z-SNAPSHOT)
+    body:
+      encoding: ASCII-8BIT
+      string: '{"email":"mb@example.com","ldap_auth":false,"first_name":"meta","last_login":"2018-05-12T15:11:48.600Z","is_active":true,"is_qbnewb":true,"is_superuser":true,"id":1,"last_name":"base","date_joined":"2018-05-12T10:50:41.992Z","common_name":"meta
+        base","google_auth":false}'
+    http_version: 
+  recorded_at: Sat, 12 May 2018 15:11:44 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
手始めに[`GET /api/user/current`](https://github.com/metabase/metabase/blob/master/docs/api-documentation.md#get-apiusercurrent)を追加します。

- エンドポイントをどんどん実装すると巨大になるのでリソースごとにモジュール切ることにした
- 既存の`Client#login`をendpoint/sessionに移す
- connectionをモジュールにしてヘッダ追加やエラーレスポンスの処理を任せる
  - リクエスト・レスポンス処理のモジュール化は別PRでやる