### PR TITLE
Ruby version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+AllCops:
+  TargetRubyVersion: 2.3
+
 Style/Documentation:
   Enabled: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 2.5
   - 2.4
+  - 2.3
 
 before_install:
   - gem install bundler -v 1.16.1

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'bundler/setup'
 require 'metabase'

--- a/lib/metabase.rb
+++ b/lib/metabase.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'metabase/version'
 require 'metabase/client'
 

--- a/lib/metabase/client.rb
+++ b/lib/metabase/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'metabase/connection'
 require 'metabase/endpoint'
 

--- a/lib/metabase/connection.rb
+++ b/lib/metabase/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'faraday'
 require 'faraday_middleware'
 require 'metabase/error'

--- a/lib/metabase/endpoint.rb
+++ b/lib/metabase/endpoint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'metabase/endpoint/session'
 require 'metabase/endpoint/user'
 

--- a/lib/metabase/endpoint/session.rb
+++ b/lib/metabase/endpoint/session.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Metabase
   module Endpoint
     module Session

--- a/lib/metabase/endpoint/user.rb
+++ b/lib/metabase/endpoint/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Metabase
   module Endpoint
     module User

--- a/lib/metabase/error.rb
+++ b/lib/metabase/error.rb
@@ -5,7 +5,7 @@ module Metabase
         case response.status
         when 400 then BadRequest
         end
-      klass.new(response) if klass
+      klass&.new(response)
     end
 
     def initialize(response = nil)

--- a/lib/metabase/error.rb
+++ b/lib/metabase/error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Metabase
   class Error < StandardError
     def self.from_response(response)

--- a/lib/metabase/version.rb
+++ b/lib/metabase/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Metabase
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.1.0'
 end

--- a/metabase.gemspec
+++ b/metabase.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.3'
+
   spec.add_runtime_dependency 'faraday', '~> 0.8'
   spec.add_runtime_dependency 'faraday_middleware'
 

--- a/metabase.gemspec
+++ b/metabase.gemspec
@@ -1,4 +1,6 @@
 
+# frozen_string_literal: true
+
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'metabase/version'

--- a/spec/metabase/endpoint/session_spec.rb
+++ b/spec/metabase/endpoint/session_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Metabase::Endpoint::Session do
   let(:client) do
     Metabase::Client.new(

--- a/spec/metabase/endpoint/user_spec.rb
+++ b/spec/metabase/endpoint/user_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Metabase::Endpoint::User do
   let(:client) do
     Metabase::Client.new(

--- a/spec/metabase_spec.rb
+++ b/spec/metabase_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Metabase do
   it 'has a version number' do
     expect(Metabase::VERSION).not_to be nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/setup'
 require 'metabase'
 require 'vcr'


### PR DESCRIPTION
Ruby 2.2はまもなくEOLなので、サポート対象を2.3以降にしてsafe navigation operatorを積極的に使っていくことにします。

- CI対象にRuby2.3を追加
- gemspecで`required_ruby_version = '>= 2.3'`にした
- rubocopを`TargetRubyVersion: 2.3`にしたら`frozen_string_literal: true`使えと出てきた
  - Ruby3で実際にそうなるかは未定だし、ファイルに余計なマジックコメントが混じるのがあれな感じはある
  - だが開発当初で対応コストもないし、文字列リテラルを破壊しなくなって設計上いいよねってことで有効でいくことにした
  - rubocop -aで自動でマジックコメント入るし、Ruby3でfrozen_string_literal入った場合はTargetRubyVersionを上げれば自動で消してくれるはず