### PR TITLE
Add common request method

### DIFF
--- a/lib/metabase/connection.rb
+++ b/lib/metabase/connection.rb
@@ -6,7 +6,37 @@ require 'metabase/error'
 
 module Metabase
   module Connection
+    def get(path, params = {})
+      request(:get, path, params)
+    end
+
+    def post(path, params = {})
+      request(:post, path, params)
+    end
+
+    def put(path, params = {})
+      request(:put, path, params)
+    end
+
+    def delete(path, params = {})
+      request(:delete, path, params)
+    end
+
+    def head(path, params = {})
+      request(:head, path, params)
+    end
+
     private
+
+    def request(method, path, params)
+      response = connection.public_send(method, path, params) do |request|
+        request.headers['X-Metabase-Session'] = @token if @token
+      end
+
+      error = Error.from_response(response)
+      raise error if error
+      response.body
+    end
 
     def connection
       @connection ||= Faraday.new(url: @url) do |c|

--- a/lib/metabase/endpoint/session.rb
+++ b/lib/metabase/endpoint/session.rb
@@ -5,10 +5,8 @@ module Metabase
     module Session
       def login
         params = { username: @username, password: @password }
-        response = connection.post '/api/session', params
-        error = Error.from_response(response)
-        raise error if error
-        @token = response.body['id']
+        response = post('/api/session', params)
+        @token = response['id']
       end
     end
   end

--- a/lib/metabase/endpoint/user.rb
+++ b/lib/metabase/endpoint/user.rb
@@ -4,14 +4,7 @@ module Metabase
   module Endpoint
     module User
       def current_user
-        response = connection.get do |req|
-          req.url '/api/user/current'
-          req.headers['X-Metabase-Session'] = @token
-        end
-
-        error = Error.from_response(response)
-        raise error if error
-        response.body
+        get('/api/user/current')
       end
     end
   end


### PR DESCRIPTION
リクエスト・レスポンス処理を共通のメソッドにしました。

- get,post,put,delete,headを定義して、内部でFaradayのそれぞれのメソッドを呼び出す
- [run_request](https://github.com/lostisland/faraday/blob/master/lib/faraday/connection.rb#L371)を使ってもいいけどsendにした
  - get,post...だと同じインタフェースのまま第二引数のパラメータをHTTPメソッドによっていい感じにしてくれる（GETならQuery string、POSTならリクエストボディとして扱われる）ので、こちらが振り分けてやる必要がなく、行数が減る
  - [get head delete](https://github.com/lostisland/faraday/blob/master/lib/faraday/connection.rb#L135)と[post put patch](https://github.com/lostisland/faraday/blob/master/lib/faraday/connection.rb#L172)で定義を分けているのだなあ