### PR TITLE
Add error classes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,3 +7,10 @@ Style/Documentation:
 Metrics/BlockLength:
   Exclude:
     - spec/**/*.rb
+
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - lib/metabase/error.rb
+
+Metrics/MethodLength:
+  Max: 20

--- a/lib/metabase/error.rb
+++ b/lib/metabase/error.rb
@@ -6,6 +6,14 @@ module Metabase
       klass =
         case response.status
         when 400 then BadRequest
+        when 401 then Unauthorized
+        when 403 then Forbidden
+        when 404 then NotFound
+        when 400..499 then ClientError
+        when 500 then InternalServerError
+        when 502 then BadGateway
+        when 503 then ServiceUnavailable
+        when 500..599 then ServerError
         end
       klass&.new(response)
     end
@@ -21,5 +29,14 @@ module Metabase
     end
   end
 
+  class ClientError < Error; end
   class BadRequest < Error; end
+  class Unauthorized < Error; end
+  class Forbidden < Error; end
+  class NotFound < Error; end
+
+  class ServerError < Error; end
+  class InternalServerError < Error; end
+  class BadGateway < Error; end
+  class ServiceUnavailable < Error; end
 end


### PR DESCRIPTION
各HTTPステータスを表したエラークラスを追加しました。
とりあえず明らかに取りうるステータスだけ入れています

その他の400、500系ステータスがきたらClientError、ServerErrorでキャッチされます（これもoctokit参考）
https://github.com/octokit/octokit.rb/blob/master/lib/octokit/error.rb