### PR TITLE
Detail error response

### DIFF
--- a/lib/metabase/error.rb
+++ b/lib/metabase/error.rb
@@ -25,7 +25,9 @@ module Metabase
 
     def build_error_message
       return nil if @response.nil?
-      @response.body
+
+      "#{@response.env.method.upcase} #{@response.env.url}: " \
+      "#{@response.status} - #{@response.body}"
     end
   end
 

--- a/lib/metabase/error.rb
+++ b/lib/metabase/error.rb
@@ -23,6 +23,8 @@ module Metabase
       super(build_error_message)
     end
 
+    private
+
     def build_error_message
       return nil if @response.nil?
 


### PR DESCRIPTION
エラーメッセージを親切にします。こんな感じになります。

レスポンスボディをそのまま入れてるので、HTMLが返ってきちゃったとき（上位のリバースプロキシでエラー返ってきたときとか）はめっちゃ長くなってしまいますが、それはまたあとでいい感じにします。

```ruby
[2] pry(main)> client.login
Metabase::BadRequest: POST http://localhost:3030/api/session: 400 - {"errors"=>{"password"=>"did not match stored password"}}
from /Users/shimoju/local/src/github.com/shimoju/metabase-ruby/lib/metabase/connection.rb:37:in `request'
[3] pry(main)> client.current_user
Metabase::Unauthorized: GET http://localhost:3030/api/user/current: 401 - Unauthenticated
from /Users/shimoju/local/src/github.com/shimoju/metabase-ruby/lib/metabase/connection.rb:37:in `request'
```