### PR TITLE
Add response handling test

### DIFF
--- a/spec/metabase/connection_spec.rb
+++ b/spec/metabase/connection_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe Metabase::Connection do
+  include_context 'client'
+
+  describe 'get' do
+    include_examples 'response handling' do
+      let(:method) { :get }
+    end
+  end
+
+  describe 'post' do
+    include_examples 'response handling' do
+      let(:method) { :post }
+    end
+  end
+
+  describe 'put' do
+    include_examples 'response handling' do
+      let(:method) { :put }
+    end
+  end
+
+  describe 'delete' do
+    include_examples 'response handling' do
+      let(:method) { :delete }
+    end
+  end
+
+  describe 'head' do
+    include_examples 'response handling' do
+      let(:method) { :head }
+    end
+  end
+end

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -22,7 +22,8 @@ RSpec.shared_examples 'response handling' do
     end
 
     it 'raises BadRequest' do
-      expect { client.send(method, path) }.to raise_error(Metabase::BadRequest)
+      message = %r{^#{method.upcase} http://#{host}#{path}: 400 - Bad Request$}
+      expect { client.send(method, path) }.to raise_error(Metabase::BadRequest, message)
     end
   end
 
@@ -33,7 +34,8 @@ RSpec.shared_examples 'response handling' do
     end
 
     it 'raises Unauthorized' do
-      expect { client.send(method, path) }.to raise_error(Metabase::Unauthorized)
+      message = %r{^#{method.upcase} http://#{host}#{path}: 401 - Unauthorized$}
+      expect { client.send(method, path) }.to raise_error(Metabase::Unauthorized, message)
     end
   end
 
@@ -44,7 +46,8 @@ RSpec.shared_examples 'response handling' do
     end
 
     it 'raises Forbidden' do
-      expect { client.send(method, path) }.to raise_error(Metabase::Forbidden)
+      message = %r{^#{method.upcase} http://#{host}#{path}: 403 - Forbidden$}
+      expect { client.send(method, path) }.to raise_error(Metabase::Forbidden, message)
     end
   end
 
@@ -55,7 +58,8 @@ RSpec.shared_examples 'response handling' do
     end
 
     it 'raises NotFound' do
-      expect { client.send(method, path) }.to raise_error(Metabase::NotFound)
+      message = %r{^#{method.upcase} http://#{host}#{path}: 404 - Not Found$}
+      expect { client.send(method, path) }.to raise_error(Metabase::NotFound, message)
     end
   end
 
@@ -66,7 +70,8 @@ RSpec.shared_examples 'response handling' do
     end
 
     it 'raises ClientError' do
-      expect { client.send(method, path) }.to raise_error(Metabase::ClientError)
+      message = %r{^#{method.upcase} http://#{host}#{path}: 499 - Client Error$}
+      expect { client.send(method, path) }.to raise_error(Metabase::ClientError, message)
     end
   end
 
@@ -77,7 +82,8 @@ RSpec.shared_examples 'response handling' do
     end
 
     it 'raises InternalServerError' do
-      expect { client.send(method, path) }.to raise_error(Metabase::InternalServerError)
+      message = %r{^#{method.upcase} http://#{host}#{path}: 500 - Internal Server Error$}
+      expect { client.send(method, path) }.to raise_error(Metabase::InternalServerError, message)
     end
   end
 
@@ -88,7 +94,8 @@ RSpec.shared_examples 'response handling' do
     end
 
     it 'raises BadGateway' do
-      expect { client.send(method, path) }.to raise_error(Metabase::BadGateway)
+      message = %r{^#{method.upcase} http://#{host}#{path}: 502 - Bad Gateway$}
+      expect { client.send(method, path) }.to raise_error(Metabase::BadGateway, message)
     end
   end
 
@@ -99,7 +106,8 @@ RSpec.shared_examples 'response handling' do
     end
 
     it 'raises ServiceUnavailable' do
-      expect { client.send(method, path) }.to raise_error(Metabase::ServiceUnavailable)
+      message = %r{^#{method.upcase} http://#{host}#{path}: 503 - Service Unavailable$}
+      expect { client.send(method, path) }.to raise_error(Metabase::ServiceUnavailable, message)
     end
   end
 
@@ -110,7 +118,8 @@ RSpec.shared_examples 'response handling' do
     end
 
     it 'raises ServerError' do
-      expect { client.send(method, path) }.to raise_error(Metabase::ServerError)
+      message = %r{^#{method.upcase} http://#{host}#{path}: 599 - Server Error$}
+      expect { client.send(method, path) }.to raise_error(Metabase::ServerError, message)
     end
   end
 end

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'response handling' do
+  let(:host) { 'localhost:3030' }
+  let(:path) { '/' }
+
+  context 'success' do
+    before do
+      stub_request(method, host)
+        .to_return(status: 200, body: 'OK')
+    end
+
+    it 'returns the response body' do
+      expect(client.send(method, path)).to eq('OK')
+    end
+  end
+
+  context 'server returns 400' do
+    before do
+      stub_request(method, host)
+        .to_return(status: 400, body: 'Bad Request')
+    end
+
+    it 'raises BadRequest' do
+      expect { client.send(method, path) }.to raise_error(Metabase::BadRequest)
+    end
+  end
+
+  context 'server returns 401' do
+    before do
+      stub_request(method, host)
+        .to_return(status: 401, body: 'Unauthorized')
+    end
+
+    it 'raises Unauthorized' do
+      expect { client.send(method, path) }.to raise_error(Metabase::Unauthorized)
+    end
+  end
+
+  context 'server returns 403' do
+    before do
+      stub_request(method, host)
+        .to_return(status: 403, body: 'Forbidden')
+    end
+
+    it 'raises Forbidden' do
+      expect { client.send(method, path) }.to raise_error(Metabase::Forbidden)
+    end
+  end
+
+  context 'server returns 404' do
+    before do
+      stub_request(method, host)
+        .to_return(status: 404, body: 'Not Found')
+    end
+
+    it 'raises NotFound' do
+      expect { client.send(method, path) }.to raise_error(Metabase::NotFound)
+    end
+  end
+
+  context 'server returns other 4xx' do
+    before do
+      stub_request(method, host)
+        .to_return(status: 499, body: 'Client Error')
+    end
+
+    it 'raises ClientError' do
+      expect { client.send(method, path) }.to raise_error(Metabase::ClientError)
+    end
+  end
+
+  context 'server returns 500' do
+    before do
+      stub_request(method, host)
+        .to_return(status: 500, body: 'Internal Server Error')
+    end
+
+    it 'raises InternalServerError' do
+      expect { client.send(method, path) }.to raise_error(Metabase::InternalServerError)
+    end
+  end
+
+  context 'server returns 502' do
+    before do
+      stub_request(method, host)
+        .to_return(status: 502, body: 'Bad Gateway')
+    end
+
+    it 'raises BadGateway' do
+      expect { client.send(method, path) }.to raise_error(Metabase::BadGateway)
+    end
+  end
+
+  context 'server returns 503' do
+    before do
+      stub_request(method, host)
+        .to_return(status: 503, body: 'Service Unavailable')
+    end
+
+    it 'raises ServiceUnavailable' do
+      expect { client.send(method, path) }.to raise_error(Metabase::ServiceUnavailable)
+    end
+  end
+
+  context 'server returns other 5xx' do
+    before do
+      stub_request(method, host)
+        .to_return(status: 599, body: 'Server Error')
+    end
+
+    it 'raises ServerError' do
+      expect { client.send(method, path) }.to raise_error(Metabase::ServerError)
+    end
+  end
+end

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -18,12 +18,13 @@ RSpec.shared_examples 'response handling' do
   context 'server returns 400' do
     before do
       stub_request(method, host)
-        .to_return(status: 400, body: 'Bad Request')
+        .to_return(status: 400, body: 'BadRequest')
     end
 
     it 'raises BadRequest' do
-      message = %r{^#{method.upcase} http://#{host}#{path}: 400 - Bad Request$}
-      expect { client.send(method, path) }.to raise_error(Metabase::BadRequest, message)
+      message = %r{^#{method.upcase} http://#{host}#{path}: 400 - BadRequest$}
+      expect { client.send(method, path) }
+        .to raise_error(Metabase::BadRequest, message)
     end
   end
 
@@ -35,7 +36,8 @@ RSpec.shared_examples 'response handling' do
 
     it 'raises Unauthorized' do
       message = %r{^#{method.upcase} http://#{host}#{path}: 401 - Unauthorized$}
-      expect { client.send(method, path) }.to raise_error(Metabase::Unauthorized, message)
+      expect { client.send(method, path) }
+        .to raise_error(Metabase::Unauthorized, message)
     end
   end
 
@@ -47,79 +49,88 @@ RSpec.shared_examples 'response handling' do
 
     it 'raises Forbidden' do
       message = %r{^#{method.upcase} http://#{host}#{path}: 403 - Forbidden$}
-      expect { client.send(method, path) }.to raise_error(Metabase::Forbidden, message)
+      expect { client.send(method, path) }
+        .to raise_error(Metabase::Forbidden, message)
     end
   end
 
   context 'server returns 404' do
     before do
       stub_request(method, host)
-        .to_return(status: 404, body: 'Not Found')
+        .to_return(status: 404, body: 'NotFound')
     end
 
     it 'raises NotFound' do
-      message = %r{^#{method.upcase} http://#{host}#{path}: 404 - Not Found$}
-      expect { client.send(method, path) }.to raise_error(Metabase::NotFound, message)
+      message = %r{^#{method.upcase} http://#{host}#{path}: 404 - NotFound$}
+      expect { client.send(method, path) }
+        .to raise_error(Metabase::NotFound, message)
     end
   end
 
   context 'server returns other 4xx' do
     before do
       stub_request(method, host)
-        .to_return(status: 499, body: 'Client Error')
+        .to_return(status: 499, body: 'ClientError')
     end
 
     it 'raises ClientError' do
-      message = %r{^#{method.upcase} http://#{host}#{path}: 499 - Client Error$}
-      expect { client.send(method, path) }.to raise_error(Metabase::ClientError, message)
+      message = %r{^#{method.upcase} http://#{host}#{path}: 499 - ClientError$}
+      expect { client.send(method, path) }
+        .to raise_error(Metabase::ClientError, message)
     end
   end
 
   context 'server returns 500' do
     before do
       stub_request(method, host)
-        .to_return(status: 500, body: 'Internal Server Error')
+        .to_return(status: 500, body: 'InternalServerError')
     end
 
     it 'raises InternalServerError' do
-      message = %r{^#{method.upcase} http://#{host}#{path}: 500 - Internal Server Error$}
-      expect { client.send(method, path) }.to raise_error(Metabase::InternalServerError, message)
+      message =
+        %r{^#{method.upcase} http://#{host}#{path}: 500 - InternalServerError$}
+      expect { client.send(method, path) }
+        .to raise_error(Metabase::InternalServerError, message)
     end
   end
 
   context 'server returns 502' do
     before do
       stub_request(method, host)
-        .to_return(status: 502, body: 'Bad Gateway')
+        .to_return(status: 502, body: 'BadGateway')
     end
 
     it 'raises BadGateway' do
-      message = %r{^#{method.upcase} http://#{host}#{path}: 502 - Bad Gateway$}
-      expect { client.send(method, path) }.to raise_error(Metabase::BadGateway, message)
+      message = %r{^#{method.upcase} http://#{host}#{path}: 502 - BadGateway$}
+      expect { client.send(method, path) }
+        .to raise_error(Metabase::BadGateway, message)
     end
   end
 
   context 'server returns 503' do
     before do
       stub_request(method, host)
-        .to_return(status: 503, body: 'Service Unavailable')
+        .to_return(status: 503, body: 'ServiceUnavailable')
     end
 
     it 'raises ServiceUnavailable' do
-      message = %r{^#{method.upcase} http://#{host}#{path}: 503 - Service Unavailable$}
-      expect { client.send(method, path) }.to raise_error(Metabase::ServiceUnavailable, message)
+      message =
+        %r{^#{method.upcase} http://#{host}#{path}: 503 - ServiceUnavailable$}
+      expect { client.send(method, path) }
+        .to raise_error(Metabase::ServiceUnavailable, message)
     end
   end
 
   context 'server returns other 5xx' do
     before do
       stub_request(method, host)
-        .to_return(status: 599, body: 'Server Error')
+        .to_return(status: 599, body: 'ServerError')
     end
 
     it 'raises ServerError' do
-      message = %r{^#{method.upcase} http://#{host}#{path}: 599 - Server Error$}
-      expect { client.send(method, path) }.to raise_error(Metabase::ServerError, message)
+      message = %r{^#{method.upcase} http://#{host}#{path}: 599 - ServerError$}
+      expect { client.send(method, path) }
+        .to raise_error(Metabase::ServerError, message)
     end
   end
 end

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'webmock/rspec'


### PR DESCRIPTION
Connectionモジュールのリクエストメソッドget,post,put,delete,headのテストを追加します。
shared_examplesを使ってそれぞれにおいてすべてのパターンをテストできるようにしてみました。
（今の実装だとそこまでしなくてもって感じですが、まあ勉強のため）