### PR TITLE
Add params arg

### DIFF
--- a/lib/metabase/endpoint/card.rb
+++ b/lib/metabase/endpoint/card.rb
@@ -3,8 +3,8 @@
 module Metabase
   module Endpoint
     module Card
-      def cards
-        get('/api/card')
+      def cards(params = {})
+        get('/api/card', params)
       end
     end
   end

--- a/lib/metabase/endpoint/session.rb
+++ b/lib/metabase/endpoint/session.rb
@@ -3,8 +3,8 @@
 module Metabase
   module Endpoint
     module Session
-      def login
-        params = { username: @username, password: @password }
+      def login(params = {})
+        params = { username: @username, password: @password }.merge(params)
         response = post('/api/session', params)
         @token = response['id']
       end

--- a/lib/metabase/endpoint/user.rb
+++ b/lib/metabase/endpoint/user.rb
@@ -3,8 +3,8 @@
 module Metabase
   module Endpoint
     module User
-      def current_user
-        get('/api/user/current')
+      def current_user(params = {})
+        get('/api/user/current', params)
       end
     end
   end


### PR DESCRIPTION
`GET /api/card`はquery stringでオプションを指定できるので、params引数を追加しました。
https://github.com/metabase/metabase/blob/master/docs/api-documentation.md#get-apicard

`client.cards({ f: 'archived' })`のように使えます。
キーワード引数で受け取れるようにしてもいいけど、Metabase側のパラメータが追加・変更されるたびに対応が必要なのが面倒です。
最後の引数がハッシュのときは`{}`を省略できる仕様を使えば、`client.cards(f: 'archived')`と書けます。（キーワード引数の導入前によく使われていたやつ）

また、すべてのメソッドにparams引数を追加するようにします。
[`GET /api/user/current`](https://github.com/metabase/metabase/blob/master/docs/api-documentation.md#get-apiusercurrent)など指定できるオプションがないものもありますが、

- メソッド間のインタフェースを統一する
- オプションが追加されたときや、ドキュメントにないけど実は指定できるオプションがある、みたいなことがあったときに柔軟に対応できる

という理由。

loginではusername,passwordが引数で指定されればそれを、なければ@usernameを使用するようにしました。