### PR TITLE
Add Metabase::Endpoint::Async

### DIFF
--- a/lib/metabase/endpoint.rb
+++ b/lib/metabase/endpoint.rb
@@ -2,6 +2,7 @@
 
 require 'metabase/endpoint/activity'
 require 'metabase/endpoint/alert'
+require 'metabase/endpoint/async'
 require 'metabase/endpoint/card'
 require 'metabase/endpoint/collection'
 require 'metabase/endpoint/dashboard'
@@ -18,6 +19,7 @@ module Metabase
   module Endpoint
     include Activity
     include Alert
+    include Async
     include Card
     include Collection
     include Dashboard

--- a/lib/metabase/endpoint/async.rb
+++ b/lib/metabase/endpoint/async.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Metabase
+  module Endpoint
+    module Async
+      def running_jobs(params = {})
+        get('/api/async/running-jobs', params)
+      end
+    end
+  end
+end

--- a/spec/metabase/endpoint/async_spec.rb
+++ b/spec/metabase/endpoint/async_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.describe Metabase::Endpoint::Async do
+  include_context 'login'
+
+  describe 'running_jobs', vcr: true do
+    context 'success' do
+      it 'returns all running jobs' do
+        running_jobs = client.running_jobs
+        expect(running_jobs).to be_kind_of(Array)
+      end
+    end
+  end
+end

--- a/spec/vcr_cassettes/Metabase_Endpoint_Async/running_jobs/success/returns_all_running_jobs.yml
+++ b/spec/vcr_cassettes/Metabase_Endpoint_Async/running_jobs/success/returns_all_running_jobs.yml
@@ -1,0 +1,85 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:3030/api/session
+    body:
+      encoding: UTF-8
+      string: '{"username":"mb@example.com","password":"p@ssw0rd"}'
+    headers:
+      User-Agent:
+      - MetabaseRuby/0.1.0 (ruby2.5.1)
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 20 May 2018 12:47:29 GMT
+      Cache-Control:
+      - max-age=0, no-cache, must-revalidate, proxy-revalidate
+      Expires:
+      - Tue, 03 Jul 2001 06:00:00 GMT
+      Last-Modified:
+      - Sun, 20 May 2018 12:47:29 +0000
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Jetty(9.2.z-SNAPSHOT)
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"72f7d16f-9b75-4e10-a8a7-1d9ec53f4fd1"}'
+    http_version: 
+  recorded_at: Sun, 20 May 2018 12:47:28 GMT
+- request:
+    method: get
+    uri: http://localhost:3030/api/async/running-jobs
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - MetabaseRuby/0.1.0 (ruby2.5.1)
+      X-Metabase-Session:
+      - 72f7d16f-9b75-4e10-a8a7-1d9ec53f4fd1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 20 May 2018 12:47:29 GMT
+      Cache-Control:
+      - max-age=0, no-cache, must-revalidate, proxy-revalidate
+      Expires:
+      - Tue, 03 Jul 2001 06:00:00 GMT
+      Last-Modified:
+      - Sun, 20 May 2018 12:47:29 +0000
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Jetty(9.2.z-SNAPSHOT)
+    body:
+      encoding: ASCII-8BIT
+      string: "[]"
+    http_version: 
+  recorded_at: Sun, 20 May 2018 12:47:28 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
2周目は今までに追加していないエンドポイントで、一番実装しやすいものをひとつ追加していきます。
ファイルを追加しきったら既存のファイルにメソッドを生やすだけになるし、`lib/metabase/endpoint.rb`のコンフリクトの心配もほぼなくなるのでメソッドを追加しやすくなるはず。

https://github.com/metabase/metabase/blob/master/docs/api-documentation.md#get-apiasyncrunning-jobs