### PR TITLE
Add Metabase::Endpoint::Permissions

### DIFF
--- a/lib/metabase/endpoint.rb
+++ b/lib/metabase/endpoint.rb
@@ -8,6 +8,7 @@ require 'metabase/endpoint/collection'
 require 'metabase/endpoint/dashboard'
 require 'metabase/endpoint/database'
 require 'metabase/endpoint/metric'
+require 'metabase/endpoint/permissions'
 require 'metabase/endpoint/pulse'
 require 'metabase/endpoint/segment'
 require 'metabase/endpoint/session'
@@ -25,6 +26,7 @@ module Metabase
     include Dashboard
     include Database
     include Metric
+    include Permissions
     include Pulse
     include Segment
     include Session

--- a/lib/metabase/endpoint/permissions.rb
+++ b/lib/metabase/endpoint/permissions.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Metabase
+  module Endpoint
+    module Permissions
+      def groups(params = {})
+        get('/api/permissions/group', params)
+      end
+    end
+  end
+end

--- a/spec/metabase/endpoint/permissions_spec.rb
+++ b/spec/metabase/endpoint/permissions_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.describe Metabase::Endpoint::Permissions do
+  include_context 'login'
+
+  describe 'groups', vcr: true do
+    context 'success' do
+      it 'returns all permissions groups' do
+        groups = client.groups
+        expect(groups).to be_kind_of(Array)
+      end
+    end
+  end
+end

--- a/spec/vcr_cassettes/Metabase_Endpoint_Permissions/groups/success/returns_all_permissions_groups.yml
+++ b/spec/vcr_cassettes/Metabase_Endpoint_Permissions/groups/success/returns_all_permissions_groups.yml
@@ -1,0 +1,85 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:3030/api/session
+    body:
+      encoding: UTF-8
+      string: '{"username":"mb@example.com","password":"p@ssw0rd"}'
+    headers:
+      User-Agent:
+      - MetabaseRuby/0.1.0 (ruby2.5.1)
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 20 May 2018 13:08:27 GMT
+      Cache-Control:
+      - max-age=0, no-cache, must-revalidate, proxy-revalidate
+      Expires:
+      - Tue, 03 Jul 2001 06:00:00 GMT
+      Last-Modified:
+      - Sun, 20 May 2018 13:08:27 +0000
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Jetty(9.2.z-SNAPSHOT)
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"f353955c-eb66-4526-9387-4d95c03c0795"}'
+    http_version: 
+  recorded_at: Sun, 20 May 2018 13:08:25 GMT
+- request:
+    method: get
+    uri: http://localhost:3030/api/permissions/group
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - MetabaseRuby/0.1.0 (ruby2.5.1)
+      X-Metabase-Session:
+      - f353955c-eb66-4526-9387-4d95c03c0795
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 20 May 2018 13:08:27 GMT
+      Cache-Control:
+      - max-age=0, no-cache, must-revalidate, proxy-revalidate
+      Expires:
+      - Tue, 03 Jul 2001 06:00:00 GMT
+      Last-Modified:
+      - Sun, 20 May 2018 13:08:27 +0000
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Jetty(9.2.z-SNAPSHOT)
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"id":2,"name":"Administrators","members":1},{"id":1,"name":"All Users","members":2},{"id":4,"name":"Developers","members":1}]'
+    http_version: 
+  recorded_at: Sun, 20 May 2018 13:08:25 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
このエンドポイントだけリソースが複数形`/api/permissions`なのがとても気になるけど、ファイル・クラス名はMetabaseにあわせて複数形とします。

https://github.com/metabase/metabase/blob/master/docs/api-documentation.md#get-apipermissionsgroup