### PR TITLE
Add Client#logout

### DIFF
--- a/lib/metabase/endpoint/session.rb
+++ b/lib/metabase/endpoint/session.rb
@@ -13,6 +13,13 @@ module Metabase
         response = post('/api/session', params)
         @token = response['id']
       end
+
+      def logout(params = {})
+        params = { session_id: @token }.merge(params)
+        delete('/api/session', params)
+        @token = nil
+        true
+      end
     end
   end
 end

--- a/spec/metabase/endpoint/session_spec.rb
+++ b/spec/metabase/endpoint/session_spec.rb
@@ -3,15 +3,15 @@
 RSpec.describe Metabase::Endpoint::Session do
   include_context 'client'
 
-  let(:incorrect_password) do
-    Metabase::Client.new(
-      url: 'http://localhost:3030',
-      username: 'mb@example.com',
-      password: 'incorrect'
-    )
-  end
-
   describe 'login', vcr: true do
+    let(:incorrect_password) do
+      Metabase::Client.new(
+        url: 'http://localhost:3030',
+        username: 'mb@example.com',
+        password: 'incorrect'
+      )
+    end
+
     context 'success' do
       it 'returns a session token' do
         expect(client.login).to match(/[a-z0-9-]{36}/)
@@ -21,6 +21,22 @@ RSpec.describe Metabase::Endpoint::Session do
     context 'incorrect username or password' do
       it 'raises error' do
         expect { incorrect_password.login }.to raise_error(Metabase::BadRequest)
+      end
+    end
+  end
+
+  describe 'logout', vcr: true do
+    context 'success' do
+      include_context 'login'
+
+      it 'returns true' do
+        expect(client.logout).to be(true)
+      end
+    end
+
+    context 'not logged in' do
+      it 'raises error' do
+        expect { client.logout }.to raise_error(Metabase::BadRequest)
       end
     end
   end

--- a/spec/vcr_cassettes/Metabase_Endpoint_Session/logout/not_logged_in/raises_error.yml
+++ b/spec/vcr_cassettes/Metabase_Endpoint_Session/logout/not_logged_in/raises_error.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: http://localhost:3030/api/session?session_id
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - MetabaseRuby/0.1.0 (ruby2.5.1)
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Tue, 22 May 2018 14:07:33 GMT
+      Cache-Control:
+      - max-age=0, no-cache, must-revalidate, proxy-revalidate
+      Expires:
+      - Tue, 03 Jul 2001 06:00:00 GMT
+      Last-Modified:
+      - Tue, 22 May 2018 14:07:33 +0000
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '61'
+      Server:
+      - Jetty(9.2.z-SNAPSHOT)
+    body:
+      encoding: UTF-8
+      string: '{"errors":{"session_id":"value must be a non-blank string."}}'
+    http_version: 
+  recorded_at: Tue, 22 May 2018 14:07:29 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/Metabase_Endpoint_Session/logout/success/returns_true.yml
+++ b/spec/vcr_cassettes/Metabase_Endpoint_Session/logout/success/returns_true.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:3030/api/session
+    body:
+      encoding: UTF-8
+      string: '{"username":"mb@example.com","password":"p@ssw0rd"}'
+    headers:
+      User-Agent:
+      - MetabaseRuby/0.1.0 (ruby2.5.1)
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 22 May 2018 14:07:33 GMT
+      Cache-Control:
+      - max-age=0, no-cache, must-revalidate, proxy-revalidate
+      Expires:
+      - Tue, 03 Jul 2001 06:00:00 GMT
+      Last-Modified:
+      - Tue, 22 May 2018 14:07:33 +0000
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Jetty(9.2.z-SNAPSHOT)
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"05500bc8-f39a-46b6-a77a-6254306450d8"}'
+    http_version: 
+  recorded_at: Tue, 22 May 2018 14:07:29 GMT
+- request:
+    method: delete
+    uri: http://localhost:3030/api/session?session_id=05500bc8-f39a-46b6-a77a-6254306450d8
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - MetabaseRuby/0.1.0 (ruby2.5.1)
+      X-Metabase-Session:
+      - 05500bc8-f39a-46b6-a77a-6254306450d8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Tue, 22 May 2018 14:07:33 GMT
+      Cache-Control:
+      - max-age=0, no-cache, must-revalidate, proxy-revalidate
+      Expires:
+      - Tue, 03 Jul 2001 06:00:00 GMT
+      Last-Modified:
+      - Tue, 22 May 2018 14:07:33 +0000
+      Strict-Transport-Security:
+      - max-age=31536000
+      Server:
+      - Jetty(9.2.z-SNAPSHOT)
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 22 May 2018 14:07:29 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
ログアウトできるようにします。

https://github.com/metabase/metabase/blob/master/docs/api-documentation.md#delete-apisession

loginだと最後の式の`@token = response['id']`によってセッショントークンが返り値になっていたけど、logoutはどうしようかとなって、

- `@token = nil`のnilでいいじゃん
- でも`if client.logout ...`と書くこともあるか？ならtruthyな返り値の方がよい
  - しかしエラーのときは例外上がる実装なのでそんな書き方はしないはず
- 最後の式が`@token = nil`じゃなくなったときに返り値が変わってしまう可能性がある
  - そのときに返すべき値はなんだろうか
- などと考えた結果、仕様として決めるなら、処理が完了したということでtrueを返すのが無難だろうという結論になった
- Javaとかだと、返り値を返さない関数とnull(nil)を返す関数は明確に区別されるんだなーと思った