### PR TITLE
Remove `gem install bundler` workaround on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ rvm:
   - 2.4
   - 2.3
 
-before_install:
-  - gem install bundler -v 1.16.2
-
 script:
   - bundle exec rubocop
   - bundle exec rake spec


### PR DESCRIPTION
Travisのアレ問題がようやく直ったようです。わーい
https://changelog.travis-ci.com/rubygems-updates-60220

workaroundはもう不要なので`gem install bundler`していた箇所を削除しました。
`gem update bundler`にしようかと思ったけど、Ruby2.3〜2.5全部最新になっていたのでrubygemsとbundlerは随時最新にしてくれているぽい。もしアップデートが遅れていたら入れることにします。