### PR TITLE
Use double splat

### DIFF
--- a/lib/metabase/connection.rb
+++ b/lib/metabase/connection.rb
@@ -6,23 +6,23 @@ require 'metabase/error'
 
 module Metabase
   module Connection
-    def get(path, params = {})
+    def get(path, **params)
       request(:get, path, params)
     end
 
-    def post(path, params = {})
+    def post(path, **params)
       request(:post, path, params)
     end
 
-    def put(path, params = {})
+    def put(path, **params)
       request(:put, path, params)
     end
 
-    def delete(path, params = {})
+    def delete(path, **params)
       request(:delete, path, params)
     end
 
-    def head(path, params = {})
+    def head(path, **params)
       request(:head, path, params)
     end
 

--- a/lib/metabase/endpoint/activity.rb
+++ b/lib/metabase/endpoint/activity.rb
@@ -3,7 +3,7 @@
 module Metabase
   module Endpoint
     module Activity
-      def activities(params = {})
+      def activities(**params)
         get('/api/activity', params)
       end
     end

--- a/lib/metabase/endpoint/alert.rb
+++ b/lib/metabase/endpoint/alert.rb
@@ -3,7 +3,7 @@
 module Metabase
   module Endpoint
     module Alert
-      def alerts(params = {})
+      def alerts(**params)
         get('/api/alert', params)
       end
     end

--- a/lib/metabase/endpoint/async.rb
+++ b/lib/metabase/endpoint/async.rb
@@ -3,7 +3,7 @@
 module Metabase
   module Endpoint
     module Async
-      def running_jobs(params = {})
+      def running_jobs(**params)
         get('/api/async/running-jobs', params)
       end
     end

--- a/lib/metabase/endpoint/card.rb
+++ b/lib/metabase/endpoint/card.rb
@@ -3,11 +3,11 @@
 module Metabase
   module Endpoint
     module Card
-      def cards(params = {})
+      def cards(**params)
         get('/api/card', params)
       end
 
-      def card(card_id, params = {})
+      def card(card_id, **params)
         get("/api/card/#{card_id}", params)
       end
     end

--- a/lib/metabase/endpoint/collection.rb
+++ b/lib/metabase/endpoint/collection.rb
@@ -3,7 +3,7 @@
 module Metabase
   module Endpoint
     module Collection
-      def collections(params = {})
+      def collections(**params)
         get('/api/collection', params)
       end
     end

--- a/lib/metabase/endpoint/dashboard.rb
+++ b/lib/metabase/endpoint/dashboard.rb
@@ -3,7 +3,7 @@
 module Metabase
   module Endpoint
     module Dashboard
-      def dashboards(params = {})
+      def dashboards(**params)
         get('/api/dashboard', params)
       end
     end

--- a/lib/metabase/endpoint/database.rb
+++ b/lib/metabase/endpoint/database.rb
@@ -3,7 +3,7 @@
 module Metabase
   module Endpoint
     module Database
-      def databases(params = {})
+      def databases(**params)
         get('/api/database', params)
       end
     end

--- a/lib/metabase/endpoint/metric.rb
+++ b/lib/metabase/endpoint/metric.rb
@@ -3,7 +3,7 @@
 module Metabase
   module Endpoint
     module Metric
-      def metrics(params = {})
+      def metrics(**params)
         get('/api/metric', params)
       end
     end

--- a/lib/metabase/endpoint/permissions.rb
+++ b/lib/metabase/endpoint/permissions.rb
@@ -3,7 +3,7 @@
 module Metabase
   module Endpoint
     module Permissions
-      def groups(params = {})
+      def groups(**params)
         get('/api/permissions/group', params)
       end
     end

--- a/lib/metabase/endpoint/public.rb
+++ b/lib/metabase/endpoint/public.rb
@@ -3,7 +3,7 @@
 module Metabase
   module Endpoint
     module Public
-      def public_card(card_uuid, params = {})
+      def public_card(card_uuid, **params)
         get("/api/public/card/#{card_uuid}", params)
       end
     end

--- a/lib/metabase/endpoint/pulse.rb
+++ b/lib/metabase/endpoint/pulse.rb
@@ -3,7 +3,7 @@
 module Metabase
   module Endpoint
     module Pulse
-      def pulses(params = {})
+      def pulses(**params)
         get('/api/pulse', params)
       end
     end

--- a/lib/metabase/endpoint/revision.rb
+++ b/lib/metabase/endpoint/revision.rb
@@ -3,7 +3,7 @@
 module Metabase
   module Endpoint
     module Revision
-      def revisions(params = {})
+      def revisions(**params)
         get('/api/revision', params)
       end
     end

--- a/lib/metabase/endpoint/segment.rb
+++ b/lib/metabase/endpoint/segment.rb
@@ -3,7 +3,7 @@
 module Metabase
   module Endpoint
     module Segment
-      def segments(params = {})
+      def segments(**params)
         get('/api/segment', params)
       end
     end

--- a/lib/metabase/endpoint/session.rb
+++ b/lib/metabase/endpoint/session.rb
@@ -8,13 +8,13 @@ module Metabase
       # @param params [Hash] Request body
       # @return [String] Session token
       # @see https://github.com/metabase/metabase/blob/master/docs/api-documentation.md#post-apisession
-      def login(params = {})
+      def login(**params)
         params = { username: @username, password: @password }.merge(params)
         response = post('/api/session', params)
         @token = response['id']
       end
 
-      def logout(params = {})
+      def logout(**params)
         params = { session_id: @token }.merge(params)
         delete('/api/session', params)
         @token = nil

--- a/lib/metabase/endpoint/setting.rb
+++ b/lib/metabase/endpoint/setting.rb
@@ -3,7 +3,7 @@
 module Metabase
   module Endpoint
     module Setting
-      def settings(params = {})
+      def settings(**params)
         get('/api/setting', params)
       end
     end

--- a/lib/metabase/endpoint/setup.rb
+++ b/lib/metabase/endpoint/setup.rb
@@ -3,7 +3,7 @@
 module Metabase
   module Endpoint
     module Setup
-      def admin_checklists(params = {})
+      def admin_checklists(**params)
         get('/api/setup/admin_checklist', params)
       end
     end

--- a/lib/metabase/endpoint/table.rb
+++ b/lib/metabase/endpoint/table.rb
@@ -3,7 +3,7 @@
 module Metabase
   module Endpoint
     module Table
-      def tables(params = {})
+      def tables(**params)
         get('/api/table', params)
       end
     end

--- a/lib/metabase/endpoint/user.rb
+++ b/lib/metabase/endpoint/user.rb
@@ -3,11 +3,11 @@
 module Metabase
   module Endpoint
     module User
-      def users(params = {})
+      def users(**params)
         get('/api/user', params)
       end
 
-      def current_user(params = {})
+      def current_user(**params)
         get('/api/user/current', params)
       end
     end

--- a/lib/metabase/endpoint/util.rb
+++ b/lib/metabase/endpoint/util.rb
@@ -3,7 +3,7 @@
 module Metabase
   module Endpoint
     module Util
-      def logs(params = {})
+      def logs(**params)
         get('/api/util/logs', params)
       end
     end

--- a/lib/metabase/endpoint/x_ray.rb
+++ b/lib/metabase/endpoint/x_ray.rb
@@ -3,7 +3,7 @@
 module Metabase
   module Endpoint
     module XRay
-      def x_ray_card(card_id, params = {})
+      def x_ray_card(card_id, **params)
         get("/api/x-ray/card/#{card_id}", params)
       end
     end

--- a/spec/metabase/endpoint/session_spec.rb
+++ b/spec/metabase/endpoint/session_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe Metabase::Endpoint::Session do
         expect { incorrect_password.login }.to raise_error(Metabase::BadRequest)
       end
     end
+
+    context 'specify username and password' do
+      it 'uses the username and password' do
+        params = { username: 'mb@example.com', password: 'p@ssw0rd' }
+        expect(incorrect_password.login(params)).to match(/[a-z0-9-]{36}/)
+      end
+    end
   end
 
   describe 'logout', vcr: true do

--- a/spec/vcr_cassettes/Metabase_Endpoint_Session/login/specify_username_and_password/uses_the_username_and_password.yml
+++ b/spec/vcr_cassettes/Metabase_Endpoint_Session/login/specify_username_and_password/uses_the_username_and_password.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:3030/api/session
+    body:
+      encoding: UTF-8
+      string: '{"username":"mb@example.com","password":"p@ssw0rd"}'
+    headers:
+      User-Agent:
+      - MetabaseRuby/0.1.0 (ruby2.5.1)
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 24 May 2018 13:49:52 GMT
+      Cache-Control:
+      - max-age=0, no-cache, must-revalidate, proxy-revalidate
+      Expires:
+      - Tue, 03 Jul 2001 06:00:00 GMT
+      Last-Modified:
+      - Thu, 24 May 2018 13:49:52 +0000
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Jetty(9.2.z-SNAPSHOT)
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"8f4f07bc-5c86-4c77-9f12-b77e571e2a17"}'
+    http_version: 
+  recorded_at: Thu, 24 May 2018 13:49:50 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
`POST /api/card/:card-id/query/:export-format`を実装しようとしていて、

- `:card-id`はいいけど`:export-format`を普通の引数で渡すと、`client.query_card(1, :csv)`のようになってわかりにくい
- `client.query_card(1, format: :csv)`のようにキーワード引数を使いたい
- しかし、引数のハッシュの`{}`を省略できる仕様は最後の引数にしか使えない
- 通常引数→キーワード引数の順序で定義する必要があるので、キーワード引数を使う場合このテクニックが使えず不便
- URLパスに含むパラメータと、オプションのquery string/リクエストボディは明確に区別したい
  - paramsで全部受け取ってパスに必要なものを切り出し、残りをリクエストボディに、みたいな操作をすると複雑になっていく
  - 必須な値を表現できない
- どうしようかと思っていたところ、可変長キーワード引数(double splat, `**args`)を使えばいいことに気がついた

というわけで既存の`params = {}`になっているところを可変長キーワード引数`**params`に置き換えます。
引数がうまく渡せているかの確認のため、`#login`にテストを追加しました。
ハッシュを組み立ててそれを渡したいときは不便かもと思ったら、可変長キーワード引数にハッシュをそのまま渡せるんだなー便利


さらに考えると、`GET /api/card/:id`は`client.card(1)`でもidを表すことはわかるけど、
[`GET /api/embed/card/:token`](https://github.com/metabase/metabase/blob/master/docs/api-documentation.md#get-apiembedcardtoken)は、`client.embed_card('hoge')`じゃなくて`client.embed_card(token: 'hoge')`にしたいよなあとなる。
[`GET /api/embed/dashboard/:token/dashcard/:dashcard-id/card/:card-id`](https://github.com/metabase/metabase/blob/master/docs/api-documentation.md#get-apiembeddashboardtokendashcarddashcard-idcardcard-id)はもうだいぶわからない。
全部キーワード引数にしてしまう方がわかりやすくなるし統一感も出るなと。
`client.card(id: 1)`や`client.query_card(id: 1, format: :csv)`でも結構いい感じはする。

いまのところは「パスのパラメータで、かつリソースのidを表す引数は通常引数、それ以外はキーワード引数」というような規約でいってみて、無理ぽってなったら全部キーワード引数にしてみようかなと思う。