### PR TITLE
Add Client#query_card

### DIFF
--- a/lib/metabase/endpoint/card.rb
+++ b/lib/metabase/endpoint/card.rb
@@ -10,6 +10,10 @@ module Metabase
       def card(card_id, **params)
         get("/api/card/#{card_id}", params)
       end
+
+      def query_card(card_id, format: :json, **params)
+        post("/api/card/#{card_id}/query/#{format}", params)
+      end
     end
   end
 end

--- a/lib/metabase/endpoint/card.rb
+++ b/lib/metabase/endpoint/card.rb
@@ -11,6 +11,10 @@ module Metabase
         get("/api/card/#{card_id}", params)
       end
 
+      def query_card_with_metadata(card_id, **params)
+        post("/api/card/#{card_id}/query", params)
+      end
+
       def query_card(card_id, format: :json, **params)
         post("/api/card/#{card_id}/query/#{format}", params)
       end

--- a/lib/metabase/endpoint/public.rb
+++ b/lib/metabase/endpoint/public.rb
@@ -6,6 +6,14 @@ module Metabase
       def public_card(card_uuid, **params)
         get("/api/public/card/#{card_uuid}", params)
       end
+
+      def query_public_card_with_metadata(card_uuid, **params)
+        get("/api/public/card/#{card_uuid}/query", params)
+      end
+
+      def query_public_card(card_uuid, format: :json, **params)
+        get("/api/public/card/#{card_uuid}/query/#{format}", params)
+      end
     end
   end
 end

--- a/spec/metabase/endpoint/card_spec.rb
+++ b/spec/metabase/endpoint/card_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe Metabase::Endpoint::Card do
   include_context 'login'
+  let(:card_id) { 1 }
 
   describe 'cards', vcr: true do
     context 'success' do
@@ -15,7 +16,7 @@ RSpec.describe Metabase::Endpoint::Card do
   describe 'card', vcr: true do
     context 'success' do
       it 'returns the card' do
-        card = client.card(1)
+        card = client.card(card_id)
         expect(card).to be_kind_of(Hash)
       end
     end
@@ -24,7 +25,7 @@ RSpec.describe Metabase::Endpoint::Card do
   describe 'query_card_with_metadata', vcr: true do
     context 'success' do
       it 'returns query results of the card with metadata' do
-        result = client.query_card_with_metadata(1)
+        result = client.query_card_with_metadata(card_id)
         expect(result).to be_kind_of(Hash)
       end
     end
@@ -33,7 +34,7 @@ RSpec.describe Metabase::Endpoint::Card do
   describe 'query_card', vcr: true do
     context 'success' do
       it 'returns query results of the card' do
-        result = client.query_card(1)
+        result = client.query_card(card_id)
         expect(result).to be_kind_of(Array)
       end
     end

--- a/spec/metabase/endpoint/card_spec.rb
+++ b/spec/metabase/endpoint/card_spec.rb
@@ -21,6 +21,15 @@ RSpec.describe Metabase::Endpoint::Card do
     end
   end
 
+  describe 'query_card_with_metadata', vcr: true do
+    context 'success' do
+      it 'returns query results of the card with metadata' do
+        result = client.query_card_with_metadata(1)
+        expect(result).to be_kind_of(Hash)
+      end
+    end
+  end
+
   describe 'query_card', vcr: true do
     context 'success' do
       it 'returns query results of the card' do

--- a/spec/metabase/endpoint/card_spec.rb
+++ b/spec/metabase/endpoint/card_spec.rb
@@ -20,4 +20,13 @@ RSpec.describe Metabase::Endpoint::Card do
       end
     end
   end
+
+  describe 'query_card', vcr: true do
+    context 'success' do
+      it 'returns query results of the card' do
+        result = client.query_card(1)
+        expect(result).to be_kind_of(Array)
+      end
+    end
+  end
 end

--- a/spec/metabase/endpoint/card_spec.rb
+++ b/spec/metabase/endpoint/card_spec.rb
@@ -38,5 +38,12 @@ RSpec.describe Metabase::Endpoint::Card do
         expect(result).to be_kind_of(Array)
       end
     end
+
+    context 'specify format' do
+      it 'returns query results of the card as specified format' do
+        result = client.query_card(card_id, format: :csv)
+        expect(result).to be_kind_of(String)
+      end
+    end
   end
 end

--- a/spec/metabase/endpoint/public_spec.rb
+++ b/spec/metabase/endpoint/public_spec.rb
@@ -11,4 +11,22 @@ RSpec.describe Metabase::Endpoint::Public do
       end
     end
   end
+
+  describe 'query_public_card_with_metadata', vcr: true do
+    context 'success' do
+      it 'returns query results of the public card with metadata' do
+        result = client.query_public_card_with_metadata('6e0b99ba-5455-4bd3-b356-31d0e0c4cb74')
+        expect(result).to be_kind_of(Hash)
+      end
+    end
+  end
+
+  describe 'query_public_card', vcr: true do
+    context 'success' do
+      it 'returns query results of the public card' do
+        result = client.query_public_card('6e0b99ba-5455-4bd3-b356-31d0e0c4cb74')
+        expect(result).to be_kind_of(Array)
+      end
+    end
+  end
 end

--- a/spec/metabase/endpoint/public_spec.rb
+++ b/spec/metabase/endpoint/public_spec.rb
@@ -2,11 +2,12 @@
 
 RSpec.describe Metabase::Endpoint::Public do
   include_context 'client'
+  let(:card_uuid) { '6e0b99ba-5455-4bd3-b356-31d0e0c4cb74' }
 
   describe 'public_card', vcr: true do
     context 'success' do
       it 'returns the public card' do
-        public_card = client.public_card('6e0b99ba-5455-4bd3-b356-31d0e0c4cb74')
+        public_card = client.public_card(card_uuid)
         expect(public_card).to be_kind_of(Hash)
       end
     end
@@ -15,7 +16,7 @@ RSpec.describe Metabase::Endpoint::Public do
   describe 'query_public_card_with_metadata', vcr: true do
     context 'success' do
       it 'returns query results of the public card with metadata' do
-        result = client.query_public_card_with_metadata('6e0b99ba-5455-4bd3-b356-31d0e0c4cb74')
+        result = client.query_public_card_with_metadata(card_uuid)
         expect(result).to be_kind_of(Hash)
       end
     end
@@ -24,7 +25,7 @@ RSpec.describe Metabase::Endpoint::Public do
   describe 'query_public_card', vcr: true do
     context 'success' do
       it 'returns query results of the public card' do
-        result = client.query_public_card('6e0b99ba-5455-4bd3-b356-31d0e0c4cb74')
+        result = client.query_public_card(card_uuid)
         expect(result).to be_kind_of(Array)
       end
     end

--- a/spec/metabase/endpoint/public_spec.rb
+++ b/spec/metabase/endpoint/public_spec.rb
@@ -29,5 +29,12 @@ RSpec.describe Metabase::Endpoint::Public do
         expect(result).to be_kind_of(Array)
       end
     end
+
+    context 'specify format' do
+      it 'returns query results of the public card as specified format' do
+        result = client.query_public_card(card_uuid, format: :csv)
+        expect(result).to be_kind_of(String)
+      end
+    end
   end
 end

--- a/spec/vcr_cassettes/Metabase_Endpoint_Card/query_card/specify_format/returns_query_results_of_the_card_as_specified_format.yml
+++ b/spec/vcr_cassettes/Metabase_Endpoint_Card/query_card/specify_format/returns_query_results_of_the_card_as_specified_format.yml
@@ -1,0 +1,91 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:3030/api/session
+    body:
+      encoding: UTF-8
+      string: '{"username":"mb@example.com","password":"p@ssw0rd"}'
+    headers:
+      User-Agent:
+      - MetabaseRuby/0.1.0 (ruby2.5.1)
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 25 May 2018 13:15:48 GMT
+      Cache-Control:
+      - max-age=0, no-cache, must-revalidate, proxy-revalidate
+      Expires:
+      - Tue, 03 Jul 2001 06:00:00 GMT
+      Last-Modified:
+      - Fri, 25 May 2018 13:15:48 +0000
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Jetty(9.2.z-SNAPSHOT)
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"a95cdd1c-547a-46c9-815c-2136747c0c84"}'
+    http_version: 
+  recorded_at: Fri, 25 May 2018 13:15:42 GMT
+- request:
+    method: post
+    uri: http://localhost:3030/api/card/1/query/csv
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - MetabaseRuby/0.1.0 (ruby2.5.1)
+      X-Metabase-Session:
+      - a95cdd1c-547a-46c9-815c-2136747c0c84
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 25 May 2018 13:15:48 GMT
+      Content-Type:
+      - text/csv; charset=utf-8
+      Content-Disposition:
+      - attachment; filename="query_result_2018-05-25T13:15:48.494Z.csv"
+      Cache-Control:
+      - max-age=0, no-cache, must-revalidate, proxy-revalidate
+      Expires:
+      - Tue, 03 Jul 2001 06:00:00 GMT
+      Last-Modified:
+      - Fri, 25 May 2018 13:15:48 +0000
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Length:
+      - '21'
+      Server:
+      - Jetty(9.2.z-SNAPSHOT)
+    body:
+      encoding: UTF-8
+      string: |
+        sum
+        898612.704294044
+    http_version: 
+  recorded_at: Fri, 25 May 2018 13:15:42 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/Metabase_Endpoint_Card/query_card/success/returns_query_results_of_the_card.yml
+++ b/spec/vcr_cassettes/Metabase_Endpoint_Card/query_card/success/returns_query_results_of_the_card.yml
@@ -1,0 +1,89 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:3030/api/session
+    body:
+      encoding: UTF-8
+      string: '{"username":"mb@example.com","password":"p@ssw0rd"}'
+    headers:
+      User-Agent:
+      - MetabaseRuby/0.1.0 (ruby2.5.1)
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 24 May 2018 15:02:20 GMT
+      Cache-Control:
+      - max-age=0, no-cache, must-revalidate, proxy-revalidate
+      Expires:
+      - Tue, 03 Jul 2001 06:00:00 GMT
+      Last-Modified:
+      - Thu, 24 May 2018 15:02:20 +0000
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Jetty(9.2.z-SNAPSHOT)
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"d6055b0c-21fc-463e-bce2-20659b285503"}'
+    http_version: 
+  recorded_at: Thu, 24 May 2018 15:02:13 GMT
+- request:
+    method: post
+    uri: http://localhost:3030/api/card/1/query/json
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - MetabaseRuby/0.1.0 (ruby2.5.1)
+      X-Metabase-Session:
+      - d6055b0c-21fc-463e-bce2-20659b285503
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 24 May 2018 15:02:20 GMT
+      Content-Type:
+      - applicaton/json; charset=utf-8
+      Content-Disposition:
+      - attachment; filename="query_result_2018-05-24T15:02:20.244Z.json"
+      Cache-Control:
+      - max-age=0, no-cache, must-revalidate, proxy-revalidate
+      Expires:
+      - Tue, 03 Jul 2001 06:00:00 GMT
+      Last-Modified:
+      - Thu, 24 May 2018 15:02:20 +0000
+      Strict-Transport-Security:
+      - max-age=31536000
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Jetty(9.2.z-SNAPSHOT)
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"sum":898612.704294044}]'
+    http_version: 
+  recorded_at: Thu, 24 May 2018 15:02:13 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/Metabase_Endpoint_Card/query_card_with_metadata/success/returns_query_results_of_the_card_with_metadata.yml
+++ b/spec/vcr_cassettes/Metabase_Endpoint_Card/query_card_with_metadata/success/returns_query_results_of_the_card_with_metadata.yml
@@ -1,0 +1,89 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:3030/api/session
+    body:
+      encoding: UTF-8
+      string: '{"username":"mb@example.com","password":"p@ssw0rd"}'
+    headers:
+      User-Agent:
+      - MetabaseRuby/0.1.0 (ruby2.5.1)
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 25 May 2018 12:23:44 GMT
+      Cache-Control:
+      - max-age=0, no-cache, must-revalidate, proxy-revalidate
+      Expires:
+      - Tue, 03 Jul 2001 06:00:00 GMT
+      Last-Modified:
+      - Fri, 25 May 2018 12:23:45 +0000
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Jetty(9.2.z-SNAPSHOT)
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"d6098d46-7438-41f5-b9ce-9355915deedb"}'
+    http_version: 
+  recorded_at: Fri, 25 May 2018 12:23:42 GMT
+- request:
+    method: post
+    uri: http://localhost:3030/api/card/1/query
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - MetabaseRuby/0.1.0 (ruby2.5.1)
+      X-Metabase-Session:
+      - d6098d46-7438-41f5-b9ce-9355915deedb
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 25 May 2018 12:23:45 GMT
+      Cache-Control:
+      - max-age=0, no-cache, must-revalidate, proxy-revalidate
+      Expires:
+      - Tue, 03 Jul 2001 06:00:00 GMT
+      Last-Modified:
+      - Fri, 25 May 2018 12:23:45 +0000
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Jetty(9.2.z-SNAPSHOT)
+    body:
+      encoding: ASCII-8BIT
+      string: '{"started_at":"2018-05-25T12:23:45.074Z","json_query":{"database":1,"type":"query","query":{"source_table":2,"aggregation":[["sum",["field-id",28]]],"filter":["AND",[">",["field-id",25],2]]},"constraints":{"max-results":10000,"max-results-bare-rows":2000},"parameters":null,"cache_ttl":null},"average_execution_time":null,"status":"completed","context":"question","row_count":1,"running_time":42,"data":{"rows":[[898612.704294044]],"columns":["sum"],"native_form":{"query":"SELECT
+        sum(\"PUBLIC\".\"ORDERS\".\"TOTAL\") AS \"sum\" FROM \"PUBLIC\".\"ORDERS\"
+        WHERE \"PUBLIC\".\"ORDERS\".\"QUANTITY\" > 2","params":null},"cols":[{"description":null,"table_id":null,"special_type":"type/Income","name":"sum","source":"aggregation","remapped_from":null,"extra_info":{},"remapped_to":null,"id":null,"target":null,"display_name":"sum","base_type":"type/Float"}],"results_metadata":{"checksum":"ji7fuos6Xxyf9ZAyC0r81X/jDJUUfvXd+lBSuUupLDlsnqr13wFq7sl2jiZE+HTZOazjor9Z6SMndKTQ6cPcrJWNnABsZlRdb3ag+ER2NBU=","columns":[{"base_type":"type/Float","display_name":"sum","name":"sum","special_type":"type/Income"}]}}}'
+    http_version: 
+  recorded_at: Fri, 25 May 2018 12:23:42 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/Metabase_Endpoint_Public/query_public_card/specify_format/returns_query_results_of_the_public_card_as_specified_format.yml
+++ b/spec/vcr_cassettes/Metabase_Endpoint_Public/query_public_card/specify_format/returns_query_results_of_the_public_card_as_specified_format.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3030/api/public/card/6e0b99ba-5455-4bd3-b356-31d0e0c4cb74/query/csv
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - MetabaseRuby/0.1.0 (ruby2.5.1)
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 25 May 2018 13:15:48 GMT
+      Content-Type:
+      - text/csv; charset=utf-8
+      Content-Disposition:
+      - attachment; filename="query_result_2018-05-25T13:15:48.623Z.csv"
+      Cache-Control:
+      - max-age=0, no-cache, must-revalidate, proxy-revalidate
+      Expires:
+      - Tue, 03 Jul 2001 06:00:00 GMT
+      Last-Modified:
+      - Fri, 25 May 2018 13:15:48 +0000
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Length:
+      - '14'
+      Server:
+      - Jetty(9.2.z-SNAPSHOT)
+    body:
+      encoding: UTF-8
+      string: |
+        COUNT(ID)
+        495
+    http_version: 
+  recorded_at: Fri, 25 May 2018 13:15:42 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/Metabase_Endpoint_Public/query_public_card/success/returns_query_results_of_the_public_card.yml
+++ b/spec/vcr_cassettes/Metabase_Endpoint_Public/query_public_card/success/returns_query_results_of_the_public_card.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3030/api/public/card/6e0b99ba-5455-4bd3-b356-31d0e0c4cb74/query/json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - MetabaseRuby/0.1.0 (ruby2.5.1)
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 25 May 2018 12:46:47 GMT
+      Content-Type:
+      - applicaton/json; charset=utf-8
+      Content-Disposition:
+      - attachment; filename="query_result_2018-05-25T12:46:47.353Z.json"
+      Cache-Control:
+      - max-age=0, no-cache, must-revalidate, proxy-revalidate
+      Expires:
+      - Tue, 03 Jul 2001 06:00:00 GMT
+      Last-Modified:
+      - Fri, 25 May 2018 12:46:47 +0000
+      Strict-Transport-Security:
+      - max-age=31536000
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Jetty(9.2.z-SNAPSHOT)
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"COUNT(ID)":495}]'
+    http_version: 
+  recorded_at: Fri, 25 May 2018 12:46:42 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/Metabase_Endpoint_Public/query_public_card_with_metadata/success/returns_query_results_of_the_public_card_with_metadata.yml
+++ b/spec/vcr_cassettes/Metabase_Endpoint_Public/query_public_card_with_metadata/success/returns_query_results_of_the_public_card_with_metadata.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3030/api/public/card/6e0b99ba-5455-4bd3-b356-31d0e0c4cb74/query
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - MetabaseRuby/0.1.0 (ruby2.5.1)
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 25 May 2018 12:46:47 GMT
+      Cache-Control:
+      - max-age=0, no-cache, must-revalidate, proxy-revalidate
+      Expires:
+      - Tue, 03 Jul 2001 06:00:00 GMT
+      Last-Modified:
+      - Fri, 25 May 2018 12:46:47 +0000
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Jetty(9.2.z-SNAPSHOT)
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"columns":["COUNT(ID)"],"cols":[{"name":"COUNT(ID)","display_name":"Count(id)","base_type":"type/Integer","remapped_to":null,"remapped_from":null}],"rows":[[495]]},"json_query":{"parameters":null},"status":"completed"}'
+    http_version: 
+  recorded_at: Fri, 25 May 2018 12:46:42 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
これ実装したらだいたいできたと同じっすね

- [`POST /api/card/:card-id/query`](https://github.com/metabase/metabase/blob/master/docs/api-documentation.md#post-apicardcard-idquery)
- [`POST /api/card/:card-id/query/:export-format`](https://github.com/metabase/metabase/blob/master/docs/api-documentation.md#post-apicardcard-idqueryexport-format)
- [`GET /api/public/card/:uuid/query`](https://github.com/metabase/metabase/blob/master/docs/api-documentation.md#get-apipubliccarduuidquery)
- [`GET /api/public/card/:uuid/query/:export-format`](https://github.com/metabase/metabase/blob/master/docs/api-documentation.md#get-apipubliccarduuidqueryexport-format)

を実装します。

- `/query`と`/query/json`は同じJSONでも結果が違っていて、`/query`は画面で使うためのメタデータを含むレスポンスになっている（VCR参照）
- `/query/:format`はクエリ結果のダウンロード用API
  - プログラムからクエリ結果を使うならほぼこちらになる
- なのでこっちを短く`query_card()`にして、`/query`は`query_card_with_metadata()`とした
  - さすがに長い気もするのでもうちょっと簡潔な名前にできたらそうしたい
