### PR TITLE
Add token args

### DIFF
--- a/lib/metabase/client.rb
+++ b/lib/metabase/client.rb
@@ -8,10 +8,11 @@ module Metabase
     include Connection
     include Endpoint
 
-    def initialize(url:, username:, password:)
+    def initialize(url:, username: nil, password: nil, token: nil)
       @url = url
       @username = username
       @password = password
+      @token = token
     end
   end
 end


### PR DESCRIPTION
tokenをinitializeの引数で指定可能にします。
Googleログインしていてパスワードがない場合、プログラムからログインするのが結構面倒なので、ブラウザ上で発行されたトークンを指定して使う、みたいな用途を想定。

これ以上設定増えたら、Rubyライブラリでよくあるブロック使って設定できるようにしたほうがいいかも