### PR TITLE
Remove version for development dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,7 @@ GEM
       method_source (~> 0.9.0)
     public_suffix (3.0.2)
     rainbow (3.0.0)
-    rake (10.5.0)
+    rake (12.3.1)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
@@ -75,11 +75,11 @@ PLATFORMS
 
 DEPENDENCIES
   awesome_print
-  bundler (~> 1.16)
+  bundler
   metabase!
   pry
-  rake (~> 10.0)
-  rspec (~> 3.0)
+  rake
+  rspec
   rubocop
   simplecov
   vcr

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
-    docile (1.3.0)
+    docile (1.3.1)
     faraday (0.15.2)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.12.2)

--- a/metabase.gemspec
+++ b/metabase.gemspec
@@ -29,10 +29,10 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'faraday_middleware'
 
   spec.add_development_dependency 'awesome_print'
-  spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'vcr'


### PR DESCRIPTION
development dependenciesは特にバージョン指定する必要ないなと思ったので外してしまいます。

rakeが割と古かったので10→12になりました。