### PR TITLE
Bump up version v0.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    metabase (0.1.0)
+    metabase (0.2.0)
       faraday (~> 0.8)
       faraday_middleware
 

--- a/lib/metabase/version.rb
+++ b/lib/metabase/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Metabase
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end


### PR DESCRIPTION
ref: https://github.com/shimoju/metabase-ruby/issues/41 

metabaseという名前のgemが既にあり、削除されて使えるようになったものの、v0.1.0というバージョンはもう使えないため、バージョンを上げました。