### PR TITLE
Add bump gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     ast (2.4.0)
     awesome_print (1.8.0)
+    bump (0.6.0)
     coderay (1.1.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -75,6 +76,7 @@ PLATFORMS
 
 DEPENDENCIES
   awesome_print
+  bump
   bundler
   metabase!
   pry

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@
 
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
+require 'bump/tasks'
 
 RSpec::Core::RakeTask.new(:spec)
 

--- a/metabase.gemspec
+++ b/metabase.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'faraday_middleware'
 
   spec.add_development_dependency 'awesome_print'
+  spec.add_development_dependency 'bump'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
バージョン上げるのを簡単にするためbumpを入れます。
https://github.com/gregorym/bump

`bump major|minor|patch`でそれぞれのバージョンが上がります。
`rake bump:minor`でrake経由でも実行できるようです。