### PR TITLE
Supports `/api/dataset/:export-format` endpoint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     metabase (0.4.0)
-      faraday (>= 0.8)
+      faraday (>= 1.2.0)
       faraday_middleware
 
 GEM
@@ -18,8 +18,9 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     docile (1.3.2)
-    faraday (1.0.1)
+    faraday (1.2.0)
       multipart-post (>= 1.2, < 3)
+      ruby2_keywords
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
     hashdiff (1.0.1)
@@ -61,6 +62,7 @@ GEM
     rubocop-ast (0.0.3)
       parser (>= 2.7.0.1)
     ruby-progressbar (1.10.1)
+    ruby2_keywords (0.0.2)
     safe_yaml (1.0.5)
     simplecov (0.18.5)
       docile (~> 1.1)

--- a/lib/metabase/endpoint.rb
+++ b/lib/metabase/endpoint.rb
@@ -7,6 +7,7 @@ require 'metabase/endpoint/card'
 require 'metabase/endpoint/collection'
 require 'metabase/endpoint/dashboard'
 require 'metabase/endpoint/database'
+require 'metabase/endpoint/dataset'
 require 'metabase/endpoint/metric'
 require 'metabase/endpoint/permissions'
 require 'metabase/endpoint/public'
@@ -30,6 +31,7 @@ module Metabase
     include Collection
     include Dashboard
     include Database
+    include Dataset
     include Metric
     include Permissions
     include Public

--- a/lib/metabase/endpoint/dataset.rb
+++ b/lib/metabase/endpoint/dataset.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Metabase
+  module Endpoint
+    module Dataset
+      # Execute a query and retrieve the results in the usual format.
+      #
+      # @param query [Hash] Query. {query: 'JSON String'}
+      # @param format [Symbol, String] Export format (api, csv, json, xlsx)
+      # @return [Array<Hash>] Query results
+      # @see https://github.com/metabase/metabase/blob/master/docs/api-documentation.md#post-apidatasetexport-format
+      def query_dataset(format: :json, **params)
+        params.merge!({ headers: {"Content-Type": "application/x-www-form-urlencoded"} })
+        post("/api/dataset/#{format}", **params)
+      end
+    end
+  end
+end

--- a/lib/metabase/endpoint/dataset.rb
+++ b/lib/metabase/endpoint/dataset.rb
@@ -10,7 +10,7 @@ module Metabase
       # @return [Array<Hash>] Query results
       # @see https://github.com/metabase/metabase/blob/master/docs/api-documentation.md#post-apidatasetexport-format
       def query_dataset(format: :json, **params)
-        params.merge!({ headers: {"Content-Type": "application/x-www-form-urlencoded"} })
+        params.merge!({ headers: { 'Content-Type': 'application/x-www-form-urlencoded' } })
         post("/api/dataset/#{format}", **params)
       end
     end

--- a/metabase.gemspec
+++ b/metabase.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.5'
 
-  spec.add_runtime_dependency 'faraday', '>= 0.8'
+  spec.add_runtime_dependency 'faraday', '>= 1.2.0'
   spec.add_runtime_dependency 'faraday_middleware'
 
   spec.add_development_dependency 'amazing_print'

--- a/spec/metabase/endpoint/dataset_spec.rb
+++ b/spec/metabase/endpoint/dataset_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe Metabase::Endpoint::Dataset do
+  include_context 'login'
+
+  let(:query) {
+    '{"type":"native","native":{"query":"SELECT * FROM orders LIMIT 1;"},"database":1}'
+  }
+
+  describe 'query_dataset', vcr: true do
+    context 'success' do
+      it 'returns query results of the dataset' do
+        result = client.query_dataset(query: query)
+        expect(result).to be_kind_of(Array)
+      end
+    end
+
+    context 'specify format' do
+      it 'returns query results of the dataset as specified format' do
+        result = client.query_dataset(query: query, format: 'csv')
+        expect(result).to be_kind_of(String)
+      end
+    end
+  end
+end

--- a/spec/metabase/endpoint/dataset_spec.rb
+++ b/spec/metabase/endpoint/dataset_spec.rb
@@ -3,9 +3,7 @@
 RSpec.describe Metabase::Endpoint::Dataset do
   include_context 'login'
 
-  let(:query) {
-    '{"type":"native","native":{"query":"SELECT * FROM orders LIMIT 1;"},"database":1}'
-  }
+  let(:query) { '{"type":"native","native":{"query":"SELECT * FROM orders LIMIT 1;"},"database":1}' }
 
   describe 'query_dataset', vcr: true do
     context 'success' do

--- a/spec/vcr_cassettes/Metabase_Endpoint_Dataset/query_dataset/specify_format/returns_query_results_of_the_dataset_as_specified_format.yml
+++ b/spec/vcr_cassettes/Metabase_Endpoint_Dataset/query_dataset/specify_format/returns_query_results_of_the_dataset_as_specified_format.yml
@@ -1,0 +1,124 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:3030/api/session
+    body:
+      encoding: UTF-8
+      string: '{"username":"mb@example.com","password":"p@ssw0rd"}'
+    headers:
+      User-Agent:
+      - MetabaseRuby/0.4.0 (ruby2.6.3)
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 25 Dec 2020 07:43:35 GMT
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      Last-Modified:
+      - Fri, 25 Dec 2020 07:43:35 GMT
+      Strict-Transport-Security:
+      - max-age=31536000
+      Set-Cookie:
+      - metabase.SESSION=6f3e45e1-3155-440b-8a57-90449279ffd6;SameSite=Lax;HttpOnly;Path=/;Max-Age=1209600
+      - metabase.SESSION_ID=;Expires=Thu, 1 Jan 1970 00:00:00 GMT;Path=/
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Cache-Control:
+      - max-age=0, no-cache, must-revalidate, proxy-revalidate
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'none'; script-src 'self' 'unsafe-eval' https://maps.google.com
+        https://apis.google.com https://www.google-analytics.com https://*.googleapis.com
+        *.gstatic.com  'sha256-lMAh4yjVuDkQ9NqkK4H+YHUga+anpFs5JAuj/uZh0Rs=' 'sha256-sMNbXyc1lLzhHbH/CKs11HIQMnMkZAN2eA99WhJeEC0='
+        'sha256-JJa56hyDfUbgNfq+0nq6Qs866JKgZ/+qCq2pkDJED8k='; child-src 'self' https://accounts.google.com;
+        style-src 'self' 'unsafe-inline'; font-src 'self' ; img-src * 'self' data:;
+        connect-src 'self' metabase.us10.list-manage.com ; manifest-src 'self';
+      Content-Type:
+      - application/json;charset=utf-8
+      Expires:
+      - Tue, 03 Jul 2001 06:00:00 GMT
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Jetty(9.4.27.v20200227)
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"6f3e45e1-3155-440b-8a57-90449279ffd6"}'
+  recorded_at: Fri, 25 Dec 2020 07:43:35 GMT
+- request:
+    method: post
+    uri: http://localhost:3030/api/dataset/csv
+    body:
+      encoding: UTF-8
+      string: query=%7B%22type%22%3A%22native%22%2C%22native%22%3A%7B%22query%22%3A%22SELECT+%2A+FROM+orders+LIMIT+1%3B%22%7D%2C%22database%22%3A1%7D
+    headers:
+      User-Agent:
+      - MetabaseRuby/0.4.0 (ruby2.6.3)
+      X-Metabase-Session:
+      - 6f3e45e1-3155-440b-8a57-90449279ffd6
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 25 Dec 2020 07:43:35 GMT
+      X-Frame-Options:
+      - DENY
+      X-Accel-Buffering:
+      - 'no'
+      X-Xss-Protection:
+      - 1; mode=block
+      Last-Modified:
+      - Fri, 25 Dec 2020 07:43:35 GMT
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Disposition:
+      - attachment; filename="query_result_2020-12-25T07:43:35.905562Z.csv"
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Cache-Control:
+      - max-age=0, no-cache, must-revalidate, proxy-revalidate
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'none'; script-src 'self' 'unsafe-eval' https://maps.google.com
+        https://apis.google.com https://www.google-analytics.com https://*.googleapis.com
+        *.gstatic.com  'sha256-lMAh4yjVuDkQ9NqkK4H+YHUga+anpFs5JAuj/uZh0Rs=' 'sha256-sMNbXyc1lLzhHbH/CKs11HIQMnMkZAN2eA99WhJeEC0='
+        'sha256-JJa56hyDfUbgNfq+0nq6Qs866JKgZ/+qCq2pkDJED8k='; child-src 'self' https://accounts.google.com;
+        style-src 'self' 'unsafe-inline'; font-src 'self' ; img-src * 'self' data:;
+        connect-src 'self' metabase.us10.list-manage.com ; manifest-src 'self';
+      Content-Type:
+      - text/csv
+      Expires:
+      - Tue, 03 Jul 2001 06:00:00 GMT
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Jetty(9.4.27.v20200227)
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        ID,USER_ID,PRODUCT_ID,SUBTOTAL,TAX,TOTAL,DISCOUNT,CREATED_AT,QUANTITY
+        1,1,14,37.648145389078365,2.07,39.718145389078366,,2019-02-11T21:40:27.892,2
+  recorded_at: Fri, 25 Dec 2020 07:43:35 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vcr_cassettes/Metabase_Endpoint_Dataset/query_dataset/success/returns_query_results_of_the_dataset.yml
+++ b/spec/vcr_cassettes/Metabase_Endpoint_Dataset/query_dataset/success/returns_query_results_of_the_dataset.yml
@@ -1,0 +1,125 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:3030/api/session
+    body:
+      encoding: UTF-8
+      string: '{"username":"mb@example.com","password":"p@ssw0rd"}'
+    headers:
+      User-Agent:
+      - MetabaseRuby/0.4.0 (ruby2.6.3)
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 25 Dec 2020 07:43:35 GMT
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      Last-Modified:
+      - Fri, 25 Dec 2020 07:43:35 GMT
+      Strict-Transport-Security:
+      - max-age=31536000
+      Set-Cookie:
+      - metabase.SESSION=a065bad2-6992-47d0-9002-befbfe3ab647;SameSite=Lax;HttpOnly;Path=/;Max-Age=1209600
+      - metabase.SESSION_ID=;Expires=Thu, 1 Jan 1970 00:00:00 GMT;Path=/
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Cache-Control:
+      - max-age=0, no-cache, must-revalidate, proxy-revalidate
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'none'; script-src 'self' 'unsafe-eval' https://maps.google.com
+        https://apis.google.com https://www.google-analytics.com https://*.googleapis.com
+        *.gstatic.com  'sha256-lMAh4yjVuDkQ9NqkK4H+YHUga+anpFs5JAuj/uZh0Rs=' 'sha256-sMNbXyc1lLzhHbH/CKs11HIQMnMkZAN2eA99WhJeEC0='
+        'sha256-JJa56hyDfUbgNfq+0nq6Qs866JKgZ/+qCq2pkDJED8k='; child-src 'self' https://accounts.google.com;
+        style-src 'self' 'unsafe-inline'; font-src 'self' ; img-src * 'self' data:;
+        connect-src 'self' metabase.us10.list-manage.com ; manifest-src 'self';
+      Content-Type:
+      - application/json;charset=utf-8
+      Expires:
+      - Tue, 03 Jul 2001 06:00:00 GMT
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Jetty(9.4.27.v20200227)
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"a065bad2-6992-47d0-9002-befbfe3ab647"}'
+  recorded_at: Fri, 25 Dec 2020 07:43:35 GMT
+- request:
+    method: post
+    uri: http://localhost:3030/api/dataset/json
+    body:
+      encoding: UTF-8
+      string: query=%7B%22type%22%3A%22native%22%2C%22native%22%3A%7B%22query%22%3A%22SELECT+%2A+FROM+orders+LIMIT+1%3B%22%7D%2C%22database%22%3A1%7D
+    headers:
+      User-Agent:
+      - MetabaseRuby/0.4.0 (ruby2.6.3)
+      X-Metabase-Session:
+      - a065bad2-6992-47d0-9002-befbfe3ab647
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Fri, 25 Dec 2020 07:43:35 GMT
+      X-Frame-Options:
+      - DENY
+      X-Accel-Buffering:
+      - 'no'
+      X-Xss-Protection:
+      - 1; mode=block
+      Last-Modified:
+      - Fri, 25 Dec 2020 07:43:35 GMT
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Disposition:
+      - attachment; filename="query_result_2020-12-25T07:43:35.76056Z.json"
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Cache-Control:
+      - max-age=0, no-cache, must-revalidate, proxy-revalidate
+      X-Content-Type-Options:
+      - nosniff
+      Content-Security-Policy:
+      - default-src 'none'; script-src 'self' 'unsafe-eval' https://maps.google.com
+        https://apis.google.com https://www.google-analytics.com https://*.googleapis.com
+        *.gstatic.com  'sha256-lMAh4yjVuDkQ9NqkK4H+YHUga+anpFs5JAuj/uZh0Rs=' 'sha256-sMNbXyc1lLzhHbH/CKs11HIQMnMkZAN2eA99WhJeEC0='
+        'sha256-JJa56hyDfUbgNfq+0nq6Qs866JKgZ/+qCq2pkDJED8k='; child-src 'self' https://accounts.google.com;
+        style-src 'self' 'unsafe-inline'; font-src 'self' ; img-src * 'self' data:;
+        connect-src 'self' metabase.us10.list-manage.com ; manifest-src 'self';
+      Content-Type:
+      - application/json;charset=utf-8
+      Expires:
+      - Tue, 03 Jul 2001 06:00:00 GMT
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Jetty(9.4.27.v20200227)
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        [
+        {"CREATED_AT":"2019-02-11T21:40:27.892","PRODUCT_ID":14,"USER_ID":1,"QUANTITY":2,"ID":1,"TAX":2.07,"TOTAL":39.718145389078366,"DISCOUNT":null,"SUBTOTAL":37.648145389078365}
+        ]
+  recorded_at: Fri, 25 Dec 2020 07:43:35 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
This PR is support [`dataset` endpoint  `/api/dataset/#{format}`](https://www.metabase.com/docs/latest/api-documentation.html#post-apidatasetexport-format) .

```ruby
query = '{"type":"native","native":{"query":"SELECT * FROM orders LIMIT 1;"},"database":1}'
client.query_dataset(query: query)
# =>[{"CREATED_AT"=>"2019-02-11T21:40:27.892", "PRODUCT_ID"=>14,"USER_ID"=>1,...}]
```

This endpoint requires a `Content-Type` header for `application/x-www-form-urlencoded`, so I made it possible to set custom headers.  

