### PR TITLE
Add 2 more collection endpoints

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   metabase:
-    image: metabase/metabase:v0.35.4
+    image: metabase/metabase:v0.39.1
     ports:
       - 3030:3000
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   metabase:
-    image: metabase/metabase:v0.39.1
+    image: metabase/metabase:v0.35.4
     ports:
       - 3030:3000
     volumes:

--- a/lib/metabase/endpoint/collection.rb
+++ b/lib/metabase/endpoint/collection.rb
@@ -28,7 +28,7 @@ module Metabase
       # @param archived [Boolean]
       # @return [Array<Hash>] Parsed response JSON
       # @see https://github.com/metabase/metabase/blob/master/docs/api-documentation.md#get-apicollectioniditems
-      def collection(collection_id, **params)
+      def collection_items(collection_id, **params)
         get("/api/collection/#{collection_id}/items", **params)
       end
     end

--- a/lib/metabase/endpoint/collection.rb
+++ b/lib/metabase/endpoint/collection.rb
@@ -11,6 +11,26 @@ module Metabase
       def collections(**params)
         get('/api/collection', **params)
       end
+
+      # Fetch a specific collection.
+      #
+      # @param collection_id [Integer, String] Collection ID
+      # @return [Array<Hash>] Parsed response JSON
+      # @see https://github.com/metabase/metabase/blob/master/docs/api-documentation.md#get-apicollectionid
+      def collection(collection_id, **params)
+        get("/api/collection/#{collection_id}", **params)
+      end
+
+      # Fetch a specific collection items.
+      #
+      # @param collection_id [Integer, String] Collection ID
+      # @param model [String] value may be nil, or if non-nil, value must be one of: card, collection, dashboard, pulse, snippet.
+      # @param archived [Boolean]
+      # @return [Array<Hash>] Parsed response JSON
+      # @see https://github.com/metabase/metabase/blob/master/docs/api-documentation.md#get-apicollectioniditems
+      def collection(collection_id, **params)
+        get("/api/collection/#{collection_id}/items", **params)
+      end
     end
   end
 end

--- a/lib/metabase/endpoint/collection.rb
+++ b/lib/metabase/endpoint/collection.rb
@@ -24,7 +24,7 @@ module Metabase
       # Fetch a specific collection items.
       #
       # @param collection_id [Integer, String] Collection ID
-      # @param model [String] value may be nil, or if non-nil, value must be one of: card, collection, dashboard, pulse, snippet.
+      # @param model [String] value may be nil, or card, collection, dashboard, pulse or snippet.
       # @param archived [Boolean]
       # @return [Array<Hash>] Parsed response JSON
       # @see https://github.com/metabase/metabase/blob/master/docs/api-documentation.md#get-apicollectioniditems

--- a/spec/metabase/endpoint/collection_spec.rb
+++ b/spec/metabase/endpoint/collection_spec.rb
@@ -11,4 +11,22 @@ RSpec.describe Metabase::Endpoint::Collection do
       end
     end
   end
+
+  describe 'collection', vcr: true do
+    context 'success' do
+      it 'returns collection' do
+        collection = client.collection(1)
+        expect(collection).to be_kind_of(Array)
+      end
+    end
+  end
+
+  describe 'collection_items', vcr: true do
+    context 'success' do
+      it 'returns collection items' do
+        collection_items = client.collection_items(1)
+        expect(collection_items).to be_kind_of(Array)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Hi,
Thanks for the gem! It works great. Unfortunately, I needed two more endpoints: `/api/collection/#{collection_id}` and `/api/collection/#{collection_id}/items`. This is what this PR is trying to do.
I have some issues with CI, not sure how I can fix it. Let me know how I can make this ready to go.

Thanks!